### PR TITLE
Migrate post-processing to dedicated prepare-text script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /other-sites/*
 /rss/diagnosis/
 /lint-reports/
+/prepare-text/filters.yaml
+/prepare-text/stats/

--- a/CHANGELOG-prepare-text-refactor.md
+++ b/CHANGELOG-prepare-text-refactor.md
@@ -1,0 +1,141 @@
+# Changelog: prepare-text refactor
+
+## Summary
+
+Migrated all post-processing (filtering, text cleaning, text transformation) out of intake scripts and TTS into a new dedicated script `prepare-text/prepare_text.py`. Intake scripts now write raw content only. TTS reads pre-cleaned content only.
+
+## New files
+
+### `prepare-text/prepare_text.py`
+
+New preprocessing script that runs between intake (imap/rss) and TTS. Handles:
+
+- **Filtering**: YAML-configured rules that skip files based on metadata (from, title, source_url, etc.)
+  - Two action types: `skip` (stops processing, moves to filtered dir) and `notify` (sends Gotify, continues)
+  - Rules execute in YAML declaration order; `skip` terminates evaluation for that file
+  - LLM-based filtering via `llm_check` (sends prompt to Gemini, expects yes/no)
+  - Rule ordering validation: detects skip rules that shadow later rules, sends Gotify alert, leaves affected files unprocessed
+- **General cleaning** (all on by default, can be disabled globally or per-source in YAML):
+  - Beehiiv markdown-to-plaintext conversion and emphasis marker removal
+  - URL removal
+  - Legal citation bracket unwrap (`[t]he` → `the`)
+  - Triple dash removal
+  - Empty bracket/paren/angle removal
+  - Whitespace collapse
+  - Unsubscribe section removal
+  - "View this post on the web" removal
+  - Substack "substacks referenced above" block removal
+  - Standalone @ line removal
+  - End-of-line punctuation insertion
+- **YAML text removals** (regex patterns to strip source-specific boilerplate)
+- **YAML text replacements** (regex find/replace for pronunciation fixes etc.)
+- **Author/title prepend and append**: Adds `{from}.\n{title}.\n` to start and end of every article from metadata
+- **Empty and too-big file checks**: Moved from TTS; routes to filtered directory with reason
+- **Stats logging**: Daily JSON files in `prepare-text/stats/` with full per-file detail (which rules fired, match counts, before/after char counts, archive paths). 12-month retention with automatic rotation.
+- **Atomic per-file processing**: Read raw → process → write outputs → archive → delete raw. If anything fails mid-file, raw file stays for retry next run.
+- **Config validation**: Three layers — YAML syntax errors crash (process.sh handles), schema violations crash with clear message, rule ordering issues send targeted Gotify and skip affected files only.
+- Variables use `Final` from typing where possible (not inside loops due to Python limitation).
+
+### `prepare-text/filters.example.yaml`
+
+Documented example config with all confirmed filters and removals:
+
+**Filters:**
+- Bill Simmons NFL detection (notify via Gotify, then skip all)
+- Jessica Valenti (skip unless "the week in" in subject)
+- K-Culture/JaeHa Kim (skip when "bts" in subject)
+
+**Text removals (confirmed patterns):**
+- NYT: Advertisement lines (mid-article), Supported by, Opinion | prefix, letters-to-editor block, social media footer, Ross Douthat bio, Ezra Klein bio, Related Content
+- Substack: reader-supported publication nag, "feel free to share" prompt, substacks referenced above block, standalone @ lines, view online prompt
+- Beehiiv: plain-text disclaimer, image captions
+- Garbage Day: typos disclaimer, TikTok Video placeholder, Instagram placeholder
+- K-Culture: copyright line, unicode small-caps promotional text
+- Money Illusion: social links header
+
+**Text replacements:**
+- Keynesian → Cainzeean (pronunciation fix)
+
+**Not added (user declined):**
+- Garbage Day "P.S. here's {something}" lines
+- K-Culture Zoom meet-up promo
+
+### `prepare-text/pyproject.toml`
+
+New uv subproject. Dependencies: beautifulsoup4, google-genai, markdown, pyyaml, requests.
+
+### `PLAN-prepare-text-refactor.md`
+
+Full design plan document covering architecture, YAML schema, stats format, directory layout, and all decisions made during planning.
+
+## Modified files
+
+### `imap/parse_email.py`
+
+- **Removed**: All text transformation — URL stripping, empty bracket/paren/angle cleanup, Beehiiv markdown-to-plaintext conversion, Beehiiv emphasis marker removal, author+subject line prepending
+- **Removed**: Jessica Valenti and JaeHa Kim email filters (moved to YAML config)
+- **Removed**: `markdown_to_plain_text()` function and `markdown` import
+- **Changed**: Output directory from `text-to-speech/text-input/` to `prepare-text/text-input-raw/`
+- **Added**: `META_INTAKE_TYPE: email` for newsletters, `META_INTAKE_TYPE: link` for link mode
+- **Unchanged**: YouTube bypass (still writes directly to audio), source URL detection, Gotify notification for unknown sources
+
+### `rss/check-rss.py`
+
+- **Removed**: `is_nfl_related()` function and all NFL detection logic (moved to YAML LLM filter)
+- **Removed**: Bill Simmons skip logic — now writes all episodes with description as content
+- **Removed**: Feed title + entry title prepending for generic RSS feeds (moved to prepare_text.py)
+- **Removed**: `get_gemini_client()`, `_gemini_client`, `summary_model`, `pydantic` import, `genai` import
+- **Changed**: Output directory from `text-to-speech/text-input/` to `prepare-text/text-input-raw/`
+- **Added**: `META_INTAKE_TYPE: rss`
+- **Unchanged**: Wayback Machine fallback logic, feed staleness checks, GUID tracking
+
+### `text-to-speech/text_to_speech.py`
+
+- **Removed**: `clean_text()` function entirely (moved to prepare_text.py)
+- **Removed**: Empty-after-cleaning handling with Gotify notification and move to holding directory
+- **Removed**: Too-big file handling with Gotify notification and move to holding directory
+- **Removed**: `character_limit` variable, `shutil` and `requests` imports
+- **Changed**: Input directory from `text-input/` to `../prepare-text/text-input-cleaned/`
+- **Changed**: Content variable now reads pre-cleaned text directly (no `clean_text()` call)
+- **Changed**: Empty file check simplified to log-and-skip (no longer moves files)
+- **Added**: `META_INTAKE_TYPE` read from metadata, passed to `build_description()`
+- **Added**: `INTAKE_TYPE_LABELS` mapping and "Via: {type}" line in episode description
+- **Added**: `intake_type` parameter to `build_description()`
+
+### `process.sh`
+
+- **Added**: `prepare-text` step between RSS and TTS (`uv sync` + `uv run python3 prepare_text.py`)
+- **Removed**: Archive copy step (`cp --update=none text-to-speech/text-input/*.txt ...`) — now handled by prepare_text.py
+- **Removed**: Empty file move step (`find ./text-input -size 0 ...`) — now handled by prepare_text.py
+
+### `pyproject.toml`
+
+- **Changed**: `line-length` from 88 to 120
+
+### `.gitignore`
+
+- **Added**: `prepare-text/filters.yaml` (user's active config, not checked in)
+- **Added**: `prepare-text/stats/` (daily stats logs)
+
+## Directory layout (new)
+
+```
+prepare-text/
+  prepare_text.py              # preprocessing script
+  filters.yaml                 # gitignored — user's active config
+  filters.example.yaml         # checked in — documents schema
+  stats/                       # gitignored — daily JSON logs
+  text-input-raw/              # intake scripts write here
+  text-input-raw-archive/      # permanent archive of originals
+  text-input-cleaned/          # output for TTS
+  text-input-cleaned-archive/  # permanent archive of cleaned versions
+  text-input-filtered/         # files that hit a filter (with META_FILTERED_REASON)
+  pyproject.toml               # uv subproject
+```
+
+## Pipeline flow (updated)
+
+```
+imap/parse_email.py  →  rss/check-rss.py  →  prepare-text/prepare_text.py  →  text-to-speech/text_to_speech.py  →  dropcaster
+     (raw email)          (raw RSS)              (filter + clean)                  (TTS + MP3)                     (RSS feed)
+```

--- a/PLAN-prepare-text-refactor.md
+++ b/PLAN-prepare-text-refactor.md
@@ -1,0 +1,236 @@
+# Plan: prepare-text refactor
+
+## Overview
+
+Migrate all post-processing (filtering, text cleaning, text transformation) to a new dedicated script `prepare-text/prepare_text.py`. Intake scripts become dumb writers of raw content. TTS script becomes a dumb reader of cleaned content.
+
+## New subproject: `prepare-text/`
+
+```
+prepare-text/
+  prepare_text.py              # the new script
+  filters.yaml                 # gitignored — active config
+  filters.example.yaml         # checked in — documents schema
+  stats/                       # daily JSON logs (gitignored), 12-month retention
+  text-input-raw/              # intake scripts write here
+  text-input-raw-archive/      # permanent archive of originals
+  text-input-cleaned/          # output for TTS to read
+  text-input-cleaned-archive/  # permanent archive of cleaned versions
+  text-input-filtered/         # files that hit a filter (with META_FILTERED_REASON)
+  pyproject.toml               # uv project, extends root config
+```
+
+## Pipeline flow (process.sh)
+
+```
+imap/parse_email.py → rss/check-rss.py → prepare-text/prepare_text.py → text-to-speech/text_to_speech.py → dropcaster
+```
+
+No more archive step in process.sh — prepare_text.py owns the full lifecycle.
+
+## Changes to intake scripts
+
+### imap/parse_email.py
+
+- Remove ALL text transformation: URL stripping, empty bracket/paren/angle cleanup, author+subject prepending, Beehiiv markdown-to-plaintext, Beehiiv emphasis marker removal
+- Remove Jessica Valenti and JaeHa Kim filters
+- Write raw `msg.text` with metadata headers to `prepare-text/text-input-raw/`
+- Add `META_INTAKE_TYPE: email` for newsletters, `META_INTAKE_TYPE: link` for link mode
+- YouTube path unchanged (bypasses everything, writes directly to audio)
+
+### rss/check-rss.py
+
+- Remove Bill Simmons NFL detection and skip logic
+- Remove feed title + entry title prepending for non-NYT feeds
+- Write ALL entries (including Bill Simmons with description as content) to `prepare-text/text-input-raw/`
+- Add `META_INTAKE_TYPE: rss`
+
+## prepare_text.py — per-file pipeline
+
+All variables use `Final` annotation. Immutable chaining style.
+
+```
+for each file in text-input-raw:
+    1. Read raw file + parse metadata
+    2. Run filters (YAML order; action: notify continues, action: skip stops)
+       - If skip: add META_FILTERED_REASON, write to text-input-filtered/, log stats, delete raw, next
+       - If notify: send Gotify, continue to next rule
+    3. Beehiiv plaintext conversion (if META_SOURCE_KIND: beehiiv)
+    4. General cleaning (fixed order, configurable on/off):
+       a. URL removal
+       b. Legal bracket unwrap [t]he → the
+       c. Triple dash removal
+       d. Empty bracket/paren/angle removal
+       e. Whitespace collapse
+       f. Unsubscribe section removal
+       g. "View this post on the web" removal
+       h. Substack "substacks referenced above" + standalone @ lines
+       i. Beehiiv emphasis marker removal (if beehiiv)
+       j. End-of-line punctuation insertion
+    5. YAML text_removals (declaration order)
+    6. YAML text_replacements (declaration order)
+    7. Prepend author + title from metadata
+    8. Append author + title from metadata
+    9. Check too-big (>150k chars) → filtered if over limit
+    10. Check empty → filtered if empty
+    11. Write cleaned to text-input-cleaned/
+    12. Archive raw to text-input-raw-archive/
+    13. Archive cleaned to text-input-cleaned-archive/
+    14. Log stats
+    15. Delete raw from text-input-raw/
+```
+
+If anything fails at steps 11-14, raw file survives in text-input-raw for retry next run.
+
+## Config validation (at startup)
+
+Three layers:
+
+1. **Invalid YAML syntax** — crash, process.sh error handling sends Gotify
+2. **Valid YAML but invalid schema** (missing required fields, unknown fields, bad regex, action:notify without notify block, etc.) — crash with clear error message
+3. **Valid config but rule ordering issue** (skip rule before notify/other rules with overlapping match) — Gotify notification about the conflict, skip affected files (leave in text-input-raw), continue processing everything else
+
+Rule ordering validation: for each `skip` rule, check if any later rule's `match` is a subset of or identical to the skip rule's `match`. If so, the later rule would never fire.
+
+## Filter action types
+
+- `action: skip` (default) — skip the file, move to text-input-filtered/, stop processing further rules
+- `action: notify` — send Gotify notification, continue to next rule (does NOT stop processing)
+
+Rules execute in YAML declaration order. A `skip` action terminates rule evaluation for that file.
+
+## YAML config schema
+
+```yaml
+# --- Filters ---
+filters:
+  - match:           # required, at least one field
+      <field>:       # from, title, source_url, source_kind, source_name, intake_type
+        contains: str        # case-insensitive
+        # OR
+        not_contains: str    # case-insensitive
+    action: skip | notify    # optional, default: skip
+    reason: str              # required
+    llm_check: str           # optional — freeform prompt sent to Gemini with title+content
+    notify:                  # optional (required if action: notify)
+      priority: int          # required
+      title: str             # required
+
+# --- General cleaning (all default true, only need to specify overrides) ---
+general_cleaning:
+  <cleaning_key>: bool       # override default
+  overrides:                 # optional, per-source overrides
+    - match: {same as filter match}
+      <cleaning_key>: bool
+
+# Valid cleaning keys:
+#   url_removal, triple_dash_removal, legal_bracket_unwrap,
+#   empty_bracket_removal, whitespace_collapse, unsubscribe_removal,
+#   view_online_removal, substack_refs_removal, standalone_at_removal,
+#   beehiiv_plaintext_conversion, beehiiv_emphasis_removal,
+#   end_of_line_punctuation
+
+# --- Source-specific text removals ---
+text_removals:
+  - pattern: str             # required, valid regex
+    reason: str              # required
+    flags: str | list[str]   # optional: ignorecase, multiline, dotall
+
+# --- Pronunciation / text replacements ---
+text_replacements:
+  - pattern: str             # required, valid regex
+    replacement: str         # required
+    reason: str              # required
+    flags: str | list[str]   # optional: ignorecase, multiline, dotall
+```
+
+## Stats JSON (daily, 12-month retention)
+
+File: `prepare-text/stats/YYYY-MM-DD.json`
+
+```json
+{
+  "2026-03-09T14:20:03": {
+    "file": "20260309-...-Law Dork-....txt",
+    "raw_archive": "prepare-text/text-input-raw-archive/20260309-....txt",
+    "cleaned_archive": "prepare-text/text-input-cleaned-archive/20260309-....txt",
+    "filtered_archive": null,
+    "filters_checked": ["Jessica Valenti: only weekly roundup", "K-Culture: skip BTS"],
+    "filters_matched": [],
+    "text_removals": {"NYT advertisement lines": {"matches": 1}},
+    "text_replacements": {},
+    "general_cleaning": {"url_removal": {"matches": 14}, "empty_bracket_removal": {"matches": 7}},
+    "outcome": "cleaned",
+    "chars_before": 8432,
+    "chars_after": 7891
+  }
+}
+```
+
+For filtered files: `cleaned_archive` is null, `filtered_archive` has the path, `outcome` is "filtered".
+
+## Changes to text-to-speech/text_to_speech.py
+
+- Remove `clean_text()` entirely
+- Read from `prepare-text/text-input-cleaned/` instead of `text-input/`
+- Keep: `split_metadata()`, chunking, TTS API calls, MP3 stitching, summary generation, ID3 tag building, file cleanup
+- Add `META_INTAKE_TYPE` to the ID3 description
+- Remove empty-after-cleaning and too-big holding directory logic (moved to prepare_text.py)
+
+## Changes to process.sh
+
+- Remove archive copy step (prepare_text.py handles it)
+- Remove empty file move step
+- Add: `cd prepare-text && uv sync && uv run python3 prepare_text.py`
+- Update TTS to read from new location
+
+## .gitignore additions
+
+```
+prepare-text/filters.yaml
+prepare-text/stats/
+```
+
+(text-input-raw/, text-input-cleaned/, etc. already covered by **/*.txt)
+
+## Decisions made
+
+- YAML config format
+- All cleaning/filtering/transformation in prepare_text.py, nowhere else
+- Intake scripts write raw only
+- Both before (raw) and after (cleaned) versions archived permanently
+- filters.yaml gitignored, filters.example.yaml checked in
+- Final from typing on all local variables
+- General cleaning defaults all true, only in example YAML (user's YAML only has overrides)
+- Daily stats JSON with 12-month retention
+- Rule ordering validation: skip before overlapping rules = error, Gotify notification, affected files left in raw
+- Bill Simmons: RSS writes description as content, notify rule for NFL, skip rule for all
+- Author + title prepended AND appended to content
+- Episode description includes META_INTAKE_TYPE (email, rss, link)
+- YouTube bypass unchanged
+- Hangul left as-is (not removed)
+
+## Text removals (confirmed by user)
+
+- NYT "Advertisement" standalone lines (mid-article)
+- NYT "Supported by" standalone line
+- NYT "Opinion | ..." title prefix line
+- NYT letters-to-editor block
+- NYT social media footer
+- NYT author bios (per-columnist: Douthat, Klein — not Friedman)
+- NYT "Related Content" standalone line
+- Substack "reader-supported publication" nag
+- Substack "This post is public so feel free to share it."
+- Garbage Day "Any typos in this email are on purpose actually"
+- Garbage Day "TikTok Video: " embed placeholder
+- Garbage Day "Instagram: " embed placeholder
+- K-Culture copyright line
+- K-Culture unicode small-caps promotional text
+- Substack "substacks referenced above" block + standalone @ lines
+- "View this post on the web at" text
+- Beehiiv plain-text disclaimer
+
+## Text removals NOT added (user declined)
+
+- Garbage Day "P.S. here's {something}" lines
+- K-Culture Zoom meet-up promo

--- a/imap/parse_email.py
+++ b/imap/parse_email.py
@@ -4,7 +4,6 @@ import pathlib
 import re
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
-import markdown
 import requests
 import yt_dlp
 from bs4 import BeautifulSoup
@@ -22,7 +21,7 @@ from urllib3.util.retry import Retry
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-output_folder = "../text-to-speech/text-input"
+output_folder = "../prepare-text/text-input-raw"
 gmail_user = os.getenv("GMAIL_PODCAST_ACCOUNT")
 gmail_password = os.getenv("GMAIL_PODCAST_ACCOUNT_APP_PASSWORD")
 local_scraper_url = "http://localhost:3001/fetch"
@@ -40,15 +39,6 @@ retry_strategy = Retry(
 
 # Create an HTTPAdapter with your retry strategy
 adapter = HTTPAdapter(max_retries=retry_strategy)
-
-
-def markdown_to_plain_text(markdown_text):
-    # Convert Markdown to HTML
-    html = markdown.markdown(markdown_text)
-
-    # Use BeautifulSoup to extract text
-    soup = BeautifulSoup(html, features="html.parser")
-    return soup.get_text()
 
 
 def send_gotify_notification(title, message, priority=6) -> None:
@@ -276,10 +266,8 @@ with MailBox("imap.gmail.com").login(gmail_user, gmail_password) as mailbox:
         from_prefix_for_filename = (
             from_name_for_filename + "- " if from_name_for_filename != "" else ""
         )
-        from_line = f"{from_name_raw}.\n" if from_name_raw else ""
         subject_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", subject_raw)
         subject_for_filter_lower = subject_for_filename.lower()
-        subject_line = f"{subject_raw}.\n" if subject_raw else ""
         if subject_for_filter_lower not in {"link", "youtube"}:
             output_filename = f"{output_folder}/{date_stamp}-{from_prefix_for_filename}{subject_for_filename}.txt"
             logging.info("parsing email: %s", output_filename)
@@ -294,62 +282,20 @@ with MailBox("imap.gmail.com").login(gmail_user, gmail_password) as mailbox:
                     "Unknown email source",
                     f"No source link found for {from_email} ({subject_raw}).",
                 )
-            if source_kind == "beehiiv":
-                email_text_plain = markdown_to_plain_text(email_text_raw)
-                # Beehiiv sometimes leaves Markdown emphasis markers in plain text.
-                email_text_plain = re.sub(r"__([^_]+)__", r"\1", email_text_plain)
-                email_text_plain = re.sub(r"_([^_]+)_", r"\1", email_text_plain)
-            else:
-                email_text_plain = email_text_raw
-            email_text_without_urls = re.sub(
-                r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,5}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)",
-                "",
-                email_text_plain,
+            output_file = pathlib.Path(output_filename).open("w", encoding="utf-8")
+            metadata_block = "\n".join(
+                [
+                    f"META_FROM: {from_name_raw}",
+                    f"META_TITLE: {subject_raw}",
+                    f"META_SOURCE_URL: {source_url}",
+                    f"META_SOURCE_KIND: {source_kind}",
+                    f"META_SOURCE_NAME: {from_name_raw}",
+                    "META_INTAKE_TYPE: email",
+                ],
             )
-            email_text_without_empty_brackets = re.sub(
-                r"\[\]",
-                "",
-                email_text_without_urls,
-            )
-            email_text_without_empty_parens = re.sub(
-                r"\(\)",
-                "",
-                email_text_without_empty_brackets,
-            )
-            email_text_without_empty_angles = email_text_without_empty_parens.replace(
-                r"<>",
-                "",
-            )
-            if len(email_text_without_empty_angles) > 0:
-                newsletter_text_for_tts = (
-                    from_line + subject_line + "\n" + email_text_without_empty_angles
-                )
-            else:
-                newsletter_text_for_tts = email_text_without_empty_angles
-
-            move_to_podcast = True
-            if (
-                "Jessica Valenti" in from_name_for_filename
-                and "the week in" not in subject_for_filter_lower
-            ):
-                move_to_podcast = False
-            if "JaeHa Kim" in from_name_for_filename and "bts" in subject_for_filter_lower:
-                logging.info("Skipping K-Culture email: BTS in subject")
-                move_to_podcast = False
-            if move_to_podcast:
-                output_file = pathlib.Path(output_filename).open("w", encoding="utf-8")
-                metadata_block = "\n".join(
-                    [
-                        f"META_FROM: {from_name_raw}",
-                        f"META_TITLE: {subject_raw}",
-                        f"META_SOURCE_URL: {source_url}",
-                        f"META_SOURCE_KIND: {source_kind}",
-                        f"META_SOURCE_NAME: {from_name_raw}",
-                    ],
-                )
-                logging.info("Writing metadata block to text input")
-                output_file.write(metadata_block + "\n\n" + newsletter_text_for_tts)
-                output_file.close()
+            logging.info("Writing raw metadata and text to text input")
+            output_file.write(metadata_block + "\n\n" + email_text_raw)
+            output_file.close()
         elif subject_for_filter_lower == "youtube":
             email_text_raw = msg.text
             youtube_url = re.sub(r"[^\S]+", "", email_text_raw)
@@ -411,6 +357,7 @@ with MailBox("imap.gmail.com").login(gmail_user, gmail_password) as mailbox:
                     f"META_TITLE: {raw_title}",
                     f"META_SOURCE_URL: {original_url}",
                     "META_SOURCE_KIND: url",
+                    "META_INTAKE_TYPE: link",
                 ],
             )
             logging.info("Writing metadata block to text input")

--- a/prepare-text/filters.example.yaml
+++ b/prepare-text/filters.example.yaml
@@ -1,0 +1,146 @@
+# filters.example.yaml — Example configuration for prepare_text.py
+# Copy to filters.yaml and customize. filters.yaml is gitignored.
+#
+# Schema notes:
+# - All match conditions are AND'd and case-insensitive
+# - Valid match fields: from, title, source_url, source_kind, source_name, intake_type
+# - Match operators: {contains: "..."} or {not_contains: "..."}
+# - Filter actions: "skip" (default, stops rule evaluation) or "notify" (continues)
+# - A skip rule before other rules with overlapping match criteria is an error
+# - Valid flags for patterns: ignorecase, multiline, dotall (or a list of them)
+
+# ---------------------------------------------------------------------------
+# Filters — decide which files to skip or notify about
+# ---------------------------------------------------------------------------
+filters:
+  # NFL notification runs first (action: notify continues to next rule)
+  - match:
+      source_url: {contains: "bill-simmons"}
+    llm_check: "Is this podcast episode primarily about NFL football?"
+    action: notify
+    notify:
+      priority: 9
+      title: "Bill Simmons NFL episode detected"
+    reason: "Bill Simmons: NFL episode detected"
+
+  # Then skip all Bill Simmons (podcast feed, no article text)
+  - match:
+      source_url: {contains: "bill-simmons"}
+    action: skip
+    reason: "Bill Simmons: podcast feed, no article text"
+
+  - match:
+      from: {contains: "Jessica Valenti"}
+      title: {not_contains: "the week in"}
+    action: skip
+    reason: "Jessica Valenti: only weekly roundup"
+
+  - match:
+      from: {contains: "JaeHa Kim"}
+      title: {contains: "bts"}
+    action: skip
+    reason: "K-Culture: skip BTS episodes"
+
+# ---------------------------------------------------------------------------
+# General cleaning — all default to true; only list overrides here
+# ---------------------------------------------------------------------------
+# Available keys (all default true):
+#   url_removal, triple_dash_removal, legal_bracket_unwrap,
+#   empty_bracket_removal, whitespace_collapse, unsubscribe_removal,
+#   view_online_removal, substack_refs_removal, standalone_at_removal,
+#   beehiiv_plaintext_conversion, beehiiv_emphasis_removal,
+#   end_of_line_punctuation
+#
+# general_cleaning:
+#   url_removal: false              # globally disable URL removal
+#   overrides:
+#     - match:
+#         from: {contains: "some source"}
+#       url_removal: false           # disable URL removal for this source only
+
+# ---------------------------------------------------------------------------
+# Text removals — regex patterns to strip from content
+# ---------------------------------------------------------------------------
+text_removals:
+  - pattern: "^Advertisement$"
+    flags: multiline
+    reason: "NYT advertisement lines"
+
+  - pattern: "^Supported by$"
+    flags: multiline
+    reason: "NYT supported by line"
+
+  - pattern: "^Opinion \\| .+$"
+    flags: multiline
+    reason: "NYT Opinion title prefix"
+
+  - pattern: "The Times is committed to publishing a diversity of letters.*?letters@nytimes\\.com\\."
+    flags: dotall
+    reason: "NYT letters to editor block"
+
+  - pattern: "Follow the New York Times Opinion section on.*?Threads\\."
+    reason: "NYT social media footer"
+
+  - pattern: "Ross Douthat has been an Opinion columnist.*?Facebook$"
+    flags: [multiline, dotall]
+    reason: "NYT Ross Douthat bio"
+
+  - pattern: "Ezra Klein joined Opinion.*?Threads\\.$"
+    flags: [multiline, dotall]
+    reason: "NYT Ezra Klein bio"
+
+  - pattern: "^Related Content$"
+    flags: multiline
+    reason: "NYT related content line"
+
+  - pattern: ".+ is a reader-supported publication\\. To .+, consider becoming a .+\\."
+    reason: "Substack reader-supported nag"
+
+  - pattern: "This post is public so feel free to share it\\."
+    reason: "Substack share prompt"
+
+  - pattern: "(?:^|\\n)Substacks referenced above:.*?(?=\\n[^@\\s]|\\Z)"
+    flags: [dotall, ignorecase]
+    reason: "Substack substacks referenced above block"
+
+  - pattern: "(?m)^\\s*@\\s*$\\r?\\n?"
+    reason: "Standalone @ lines"
+
+  - pattern: "View this post on the web at\\s*(?:\\r\\n|\\r|\\n){1,2}"
+    reason: "Substack view online prompt"
+
+  - pattern: "You are reading a plain text version of this post\\. For the best experience, copy and paste this link in your browser to view the post online:"
+    reason: "Beehiiv plain-text disclaimer"
+
+  - pattern: "Any typos in this email are on purpose actually"
+    reason: "Garbage Day typos disclaimer"
+
+  - pattern: "^TikTok Video:\\s*$"
+    flags: multiline
+    reason: "Garbage Day TikTok embed placeholder"
+
+  - pattern: "^Instagram:\\s*$"
+    flags: multiline
+    reason: "Garbage Day Instagram embed placeholder"
+
+  - pattern: "\\u00a9\\s*\\d{4}\\s*JAE-HA KIM.*?All Rights Reserved"
+    flags: ignorecase
+    reason: "K-Culture copyright line"
+
+  - pattern: "[\\u1d00-\\u1d7f][\\u1d00-\\u1d7f\\s]{5,}"
+    reason: "Unicode small-caps promotional text"
+
+  - pattern: "View image: \\(.*?\\)(?:\\r\\n|\\r|\\n)?\\s*Caption: .*?\\s*.*(?:\\r\\n|\\r|\\n)?"
+    reason: "Beehiiv image captions"
+
+  - pattern: "Facebook *(?:\\r\\n|\\r|\\n)Twitter *(?:\\r\\n|\\r|\\n)LinkedIn *(?:\\r\\n|\\r|\\n)"
+    reason: "Money Illusion social links"
+
+# ---------------------------------------------------------------------------
+# Text replacements — regex find/replace for pronunciation fixes etc.
+# ---------------------------------------------------------------------------
+text_replacements:
+  - pattern: "Keynesian"
+    replacement: "Cainzeean"
+    flags: ignorecase
+    reason: "Keynesian pronunciation fix"

--- a/prepare-text/filters.example.yaml
+++ b/prepare-text/filters.example.yaml
@@ -13,33 +13,36 @@
 # Filters — decide which files to skip or notify about
 # ---------------------------------------------------------------------------
 filters:
-  # NFL notification runs first (action: notify continues to next rule)
+  # Notify first, then skip — notify runs before skip for the same match.
+  # Use action: notify to send a Gotify alert without stopping processing.
   - match:
-      source_url: {contains: "bill-simmons"}
-    llm_check: "Is this podcast episode primarily about NFL football?"
+      source_url: {contains: "example-podcast-feed"}
+    llm_check: "Does this episode discuss topic X?"
     action: notify
     notify:
       priority: 9
-      title: "Bill Simmons NFL episode detected"
-    reason: "Bill Simmons: NFL episode detected"
+      title: "Topic X episode detected"
+    reason: "Example Podcast: topic X detected"
 
-  # Then skip all Bill Simmons (podcast feed, no article text)
+  # Skip all from this feed (e.g. podcast feed with no article text)
   - match:
-      source_url: {contains: "bill-simmons"}
+      source_url: {contains: "example-podcast-feed"}
     action: skip
-    reason: "Bill Simmons: podcast feed, no article text"
+    reason: "Example Podcast: no article text"
 
+  # Skip unless title contains a specific phrase
   - match:
-      from: {contains: "Jessica Valenti"}
-      title: {not_contains: "the week in"}
+      from: {contains: "Example Author"}
+      title: {not_contains: "weekly roundup"}
     action: skip
-    reason: "Jessica Valenti: only weekly roundup"
+    reason: "Example Author: only weekly roundup editions"
 
+  # Skip when title contains a keyword
   - match:
-      from: {contains: "JaeHa Kim"}
-      title: {contains: "bts"}
+      from: {contains: "Example Newsletter"}
+      title: {contains: "off-topic"}
     action: skip
-    reason: "K-Culture: skip BTS episodes"
+    reason: "Example Newsletter: skip off-topic episodes"
 
 # ---------------------------------------------------------------------------
 # General cleaning — all default to true; only list overrides here
@@ -62,85 +65,46 @@ filters:
 # Text removals — regex patterns to strip from content
 # ---------------------------------------------------------------------------
 text_removals:
+  # Remove a standalone line (e.g. "Advertisement" mid-article)
   - pattern: "^Advertisement$"
     flags: multiline
-    reason: "NYT advertisement lines"
+    reason: "Remove standalone advertisement markers"
 
-  - pattern: "^Supported by$"
-    flags: multiline
-    reason: "NYT supported by line"
-
-  - pattern: "^Opinion \\| .+$"
-    flags: multiline
-    reason: "NYT Opinion title prefix"
-
-  - pattern: "The Times is committed to publishing a diversity of letters.*?letters@nytimes\\.com\\."
+  # Remove a multi-line block matched with dotall
+  - pattern: "Please subscribe to support our work.*?Thank you\\."
     flags: dotall
-    reason: "NYT letters to editor block"
+    reason: "Remove subscription nag block"
 
-  - pattern: "Follow the New York Times Opinion section on.*?Threads\\."
-    reason: "NYT social media footer"
+  # Remove a social media footer
+  - pattern: "Follow us on.*?Threads\\."
+    reason: "Remove social media footer"
 
-  - pattern: "Ross Douthat has been an Opinion columnist.*?Facebook$"
+  # Remove an author bio that repeats on every article
+  - pattern: "Jane Doe is a columnist for.*?$"
     flags: [multiline, dotall]
-    reason: "NYT Ross Douthat bio"
+    reason: "Remove recurring author bio"
 
-  - pattern: "Ezra Klein joined Opinion.*?Threads\\.$"
-    flags: [multiline, dotall]
-    reason: "NYT Ezra Klein bio"
-
-  - pattern: "^Related Content$"
-    flags: multiline
-    reason: "NYT related content line"
-
+  # Remove a reader-supported publication nag (generic Substack pattern)
   - pattern: ".+ is a reader-supported publication\\. To .+, consider becoming a .+\\."
-    reason: "Substack reader-supported nag"
+    reason: "Remove reader-supported nag"
 
-  - pattern: "This post is public so feel free to share it\\."
-    reason: "Substack share prompt"
-
-  - pattern: "(?:^|\\n)Substacks referenced above:.*?(?=\\n[^@\\s]|\\Z)"
-    flags: [dotall, ignorecase]
-    reason: "Substack substacks referenced above block"
-
-  - pattern: "(?m)^\\s*@\\s*$\\r?\\n?"
-    reason: "Standalone @ lines"
-
-  - pattern: "View this post on the web at\\s*(?:\\r\\n|\\r|\\n){1,2}"
-    reason: "Substack view online prompt"
-
+  # Remove platform-specific boilerplate
   - pattern: "You are reading a plain text version of this post\\. For the best experience, copy and paste this link in your browser to view the post online:"
-    reason: "Beehiiv plain-text disclaimer"
+    reason: "Remove plain-text email disclaimer"
 
-  - pattern: "Any typos in this email are on purpose actually"
-    reason: "Garbage Day typos disclaimer"
-
-  - pattern: "^TikTok Video:\\s*$"
-    flags: multiline
-    reason: "Garbage Day TikTok embed placeholder"
-
-  - pattern: "^Instagram:\\s*$"
-    flags: multiline
-    reason: "Garbage Day Instagram embed placeholder"
-
-  - pattern: "\\u00a9\\s*\\d{4}\\s*JAE-HA KIM.*?All Rights Reserved"
-    flags: ignorecase
-    reason: "K-Culture copyright line"
-
+  # Remove unicode small-caps promotional text (common in some newsletters)
   - pattern: "[\\u1d00-\\u1d7f][\\u1d00-\\u1d7f\\s]{5,}"
-    reason: "Unicode small-caps promotional text"
+    reason: "Remove unicode small-caps promotional text"
 
-  - pattern: "View image: \\(.*?\\)(?:\\r\\n|\\r|\\n)?\\s*Caption: .*?\\s*.*(?:\\r\\n|\\r|\\n)?"
-    reason: "Beehiiv image captions"
-
+  # Remove social links header (e.g. "Facebook\nTwitter\nLinkedIn\n")
   - pattern: "Facebook *(?:\\r\\n|\\r|\\n)Twitter *(?:\\r\\n|\\r|\\n)LinkedIn *(?:\\r\\n|\\r|\\n)"
-    reason: "Money Illusion social links"
+    reason: "Remove social links header"
 
 # ---------------------------------------------------------------------------
 # Text replacements — regex find/replace for pronunciation fixes etc.
 # ---------------------------------------------------------------------------
 text_replacements:
-  - pattern: "Keynesian"
-    replacement: "Cainzeean"
+  - pattern: "Worchestershire"
+    replacement: "Woostershire"
     flags: ignorecase
-    reason: "Keynesian pronunciation fix"
+    reason: "Pronunciation fix"

--- a/prepare-text/prepare_text.py
+++ b/prepare-text/prepare_text.py
@@ -1,0 +1,864 @@
+"""Text preparation pipeline: filtering, cleaning, and transformation.
+
+Reads raw text files from text-input-raw/, applies filters and cleaning rules
+from filters.yaml, and writes cleaned output to text-input-cleaned/ for TTS.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+import re
+import shutil
+from datetime import datetime, timedelta
+from typing import Final
+
+import markdown
+import requests
+import yaml
+from bs4 import BeautifulSoup
+from google import genai
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+RAW_INPUT_DIR: Final = "text-input-raw"
+RAW_ARCHIVE_DIR: Final = "text-input-raw-archive"
+CLEANED_OUTPUT_DIR: Final = "text-input-cleaned"
+CLEANED_ARCHIVE_DIR: Final = "text-input-cleaned-archive"
+FILTERED_DIR: Final = "text-input-filtered"
+STATS_DIR: Final = "stats"
+CONFIG_FILE: Final = "filters.yaml"
+CHARACTER_LIMIT: Final = 150000
+STATS_RETENTION_DAYS: Final = 365
+LLM_MODEL: Final = "gemini-3.1-flash-lite-preview"
+
+_gemini_client: genai.Client | None = None
+
+
+# ---------------------------------------------------------------------------
+# Gemini client
+# ---------------------------------------------------------------------------
+
+
+def get_gemini_client() -> genai.Client:
+    global _gemini_client  # noqa: PLW0603
+    if _gemini_client is None:
+        _gemini_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    return _gemini_client
+
+
+# ---------------------------------------------------------------------------
+# Gotify notifications
+# ---------------------------------------------------------------------------
+
+
+def send_gotify_notification(title: str, message: str, priority: int = 6) -> None:
+    final_server: Final = os.environ.get("GOTIFY_SERVER")
+    final_token: Final = os.environ.get("GOTIFY_TOKEN")
+    if not final_server or not final_token:
+        logging.warning("Gotify env vars not set; skipping notification.")
+        return
+    final_url: Final = f"{final_server}/message?token={final_token}"
+    final_data: Final = {"title": title, "message": message, "priority": priority}
+    requests.post(final_url, data=final_data, timeout=30)
+
+
+# ---------------------------------------------------------------------------
+# Metadata parsing
+# ---------------------------------------------------------------------------
+
+
+def split_metadata(raw_text: str) -> tuple[dict[str, str], str]:
+    if not raw_text.startswith("META_"):
+        return {}, raw_text
+    final_lines: Final = raw_text.splitlines()
+    metadata: Final[dict[str, str]] = {}
+    current_key: str | None = None
+    content_start: int = len(final_lines)
+    for idx, line in enumerate(final_lines):
+        if line.startswith("META_"):
+            if ":" not in line:
+                content_start = idx
+                break
+            key_raw = line.split(":", 1)[0]
+            value_raw = line.split(":", 1)[1]
+            current_key = key_raw.replace("META_", "").lower()
+            metadata[current_key] = value_raw.strip()
+            continue
+        if line.startswith((" ", "\t")) and current_key:
+            metadata[current_key] = (
+                f"{metadata.get(current_key, '')} {line.strip()}".strip()
+            )
+            continue
+        if not line.strip():
+            content_start = idx + 1
+            break
+        content_start = idx
+        break
+    final_content: Final = (
+        "\n".join(final_lines[content_start:]) if content_start < len(final_lines) else ""
+    )
+    return metadata, final_content
+
+
+# ---------------------------------------------------------------------------
+# Config loading and validation
+# ---------------------------------------------------------------------------
+
+VALID_MATCH_FIELDS: Final = frozenset(
+    {"from", "title", "source_url", "source_kind", "source_name", "intake_type"},
+)
+VALID_MATCH_OPERATORS: Final = frozenset({"contains", "not_contains"})
+VALID_ACTIONS: Final = frozenset({"skip", "notify"})
+VALID_FLAGS: Final = frozenset({"ignorecase", "multiline", "dotall"})
+VALID_CLEANING_KEYS: Final = frozenset(
+    {
+        "url_removal",
+        "triple_dash_removal",
+        "legal_bracket_unwrap",
+        "empty_bracket_removal",
+        "whitespace_collapse",
+        "unsubscribe_removal",
+        "view_online_removal",
+        "substack_refs_removal",
+        "standalone_at_removal",
+        "beehiiv_plaintext_conversion",
+        "beehiiv_emphasis_removal",
+        "end_of_line_punctuation",
+    },
+)
+
+
+def parse_flags(flags_raw: str | list[str] | None) -> int:
+    if flags_raw is None:
+        return 0
+    final_flag_list: Final = [flags_raw] if isinstance(flags_raw, str) else flags_raw
+    result: int = 0
+    for flag_name in final_flag_list:
+        if flag_name not in VALID_FLAGS:
+            msg = f"Invalid flag: {flag_name!r} (valid: {', '.join(sorted(VALID_FLAGS))})"
+            raise ValueError(msg)
+        if flag_name == "ignorecase":
+            result |= re.IGNORECASE
+        elif flag_name == "multiline":
+            result |= re.MULTILINE
+        elif flag_name == "dotall":
+            result |= re.DOTALL
+    return result
+
+
+def validate_match_block(match_block: dict, context: str) -> None:
+    if not isinstance(match_block, dict) or not match_block:
+        msg = f"{context}: 'match' must be a non-empty dict"
+        raise ValueError(msg)
+    for field, operators in match_block.items():
+        if field not in VALID_MATCH_FIELDS:
+            msg = f"{context}: unknown match field {field!r} (valid: {', '.join(sorted(VALID_MATCH_FIELDS))})"
+            raise ValueError(msg)
+        if not isinstance(operators, dict) or not operators:
+            msg = f"{context}: match field {field!r} must be a dict with operators"
+            raise ValueError(msg)
+        for op in operators:
+            if op not in VALID_MATCH_OPERATORS:
+                valid_ops = ", ".join(sorted(VALID_MATCH_OPERATORS))
+                msg = f"{context}: unknown operator {op!r} for field {field!r} (valid: {valid_ops})"
+                raise ValueError(msg)
+
+
+def validate_config(config: dict) -> None:
+    final_valid_top_keys: Final = frozenset(
+        {"filters", "general_cleaning", "text_removals", "text_replacements"},
+    )
+    for key in config:
+        if key not in final_valid_top_keys:
+            msg = f"Unknown top-level key: {key!r}"
+            raise ValueError(msg)
+
+    # Validate filters
+    for idx, filt in enumerate(config.get("filters") or []):
+        final_ctx = f"filters[{idx}]"
+        if "match" not in filt:
+            msg = f"{final_ctx}: 'match' is required"
+            raise ValueError(msg)
+        validate_match_block(filt["match"], final_ctx)
+        if "reason" not in filt:
+            msg = f"{final_ctx}: 'reason' is required"
+            raise ValueError(msg)
+        final_action = filt.get("action", "skip")
+        if final_action not in VALID_ACTIONS:
+            msg = f"{final_ctx}: invalid action {final_action!r} (valid: {', '.join(sorted(VALID_ACTIONS))})"
+            raise ValueError(msg)
+        if final_action == "notify" and "notify" not in filt:
+            msg = f"{final_ctx}: action 'notify' requires a 'notify' block"
+            raise ValueError(msg)
+        if "notify" in filt:
+            final_notify = filt["notify"]
+            if "priority" not in final_notify:
+                msg = f"{final_ctx}: notify block requires 'priority'"
+                raise ValueError(msg)
+            if "title" not in final_notify:
+                msg = f"{final_ctx}: notify block requires 'title'"
+                raise ValueError(msg)
+        if "llm_check" in filt and not isinstance(filt["llm_check"], str):
+            msg = f"{final_ctx}: 'llm_check' must be a string"
+            raise ValueError(msg)
+
+    # Validate general_cleaning
+    final_gc: Final = config.get("general_cleaning") or {}
+    for key, value in final_gc.items():
+        if key == "overrides":
+            if not isinstance(value, list):
+                msg = "general_cleaning.overrides must be a list"
+                raise ValueError(msg)
+            for oidx, override in enumerate(value):
+                final_octx = f"general_cleaning.overrides[{oidx}]"
+                if "match" not in override:
+                    msg = f"{final_octx}: 'match' is required"
+                    raise ValueError(msg)
+                validate_match_block(override["match"], final_octx)
+                for okey in override:
+                    if okey != "match" and okey not in VALID_CLEANING_KEYS:
+                        msg = f"{final_octx}: unknown key {okey!r}"
+                        raise ValueError(msg)
+        elif key not in VALID_CLEANING_KEYS:
+            msg = f"general_cleaning: unknown key {key!r}"
+            raise ValueError(msg)
+        elif not isinstance(value, bool):
+            msg = f"general_cleaning.{key}: must be a boolean"
+            raise ValueError(msg)
+
+    # Validate text_removals
+    for idx, removal in enumerate(config.get("text_removals") or []):
+        final_rctx = f"text_removals[{idx}]"
+        if "pattern" not in removal:
+            msg = f"{final_rctx}: 'pattern' is required"
+            raise ValueError(msg)
+        if "reason" not in removal:
+            msg = f"{final_rctx}: 'reason' is required"
+            raise ValueError(msg)
+        final_rflags = parse_flags(removal.get("flags"))
+        try:
+            re.compile(removal["pattern"], final_rflags)
+        except re.error as exc:
+            msg = f"{final_rctx}: invalid regex: {exc}"
+            raise ValueError(msg) from exc
+
+    # Validate text_replacements
+    for idx, repl in enumerate(config.get("text_replacements") or []):
+        final_pctx = f"text_replacements[{idx}]"
+        if "pattern" not in repl:
+            msg = f"{final_pctx}: 'pattern' is required"
+            raise ValueError(msg)
+        if "replacement" not in repl:
+            msg = f"{final_pctx}: 'replacement' is required"
+            raise ValueError(msg)
+        if "reason" not in repl:
+            msg = f"{final_pctx}: 'reason' is required"
+            raise ValueError(msg)
+        final_pflags = parse_flags(repl.get("flags"))
+        try:
+            re.compile(repl["pattern"], final_pflags)
+        except re.error as exc:
+            msg = f"{final_pctx}: invalid regex: {exc}"
+            raise ValueError(msg) from exc
+
+
+def validate_rule_ordering(filters: list[dict]) -> list[str]:
+    """Check for skip rules that shadow later rules with overlapping match criteria.
+
+    Returns list of error messages (empty if no problems).
+    """
+    errors: Final[list[str]] = []
+    for i, rule_a in enumerate(filters):
+        if rule_a.get("action", "skip") != "skip":
+            continue
+        final_match_a = rule_a["match"]
+        for j in range(i + 1, len(filters)):
+            final_rule_b = filters[j]
+            final_match_b = final_rule_b["match"]
+            # Check if match_b is a subset of or identical to match_a
+            # (meaning everything match_b matches, match_a also matches)
+            if _match_is_subset(subset=final_match_b, superset=final_match_a):
+                errors.append(
+                    f"filters[{i}] (skip, reason: {rule_a['reason']!r}) shadows "
+                    f"filters[{j}] (reason: {final_rule_b['reason']!r}) — "
+                    f"the later rule will never fire. Reorder or adjust match criteria.",
+                )
+    return errors
+
+
+def _match_is_subset(subset: dict, superset: dict) -> bool:
+    """Check if everything matched by 'subset' criteria is also matched by 'superset'.
+
+    A superset match has fewer or equal constraints — so subset must contain
+    all fields from superset with compatible operators.
+    """
+    for field, operators in superset.items():
+        if field not in subset:
+            return False
+        final_sub_ops = subset[field]
+        for op, value in operators.items():
+            if op not in final_sub_ops:
+                return False
+            if final_sub_ops[op].lower() != value.lower():
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Match evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_match(match_block: dict, metadata: dict[str, str]) -> bool:
+    for field, operators in match_block.items():
+        final_meta_value = metadata.get(field, "").lower()
+        for op, target in operators.items():
+            final_target_lower = target.lower()
+            if op == "contains" and final_target_lower not in final_meta_value:
+                return False
+            if op == "not_contains" and final_target_lower in final_meta_value:
+                return False
+    return True
+
+
+def evaluate_llm_check(prompt_template: str, metadata: dict[str, str], content: str) -> bool:
+    final_title: Final = metadata.get("title", "")
+    final_full_prompt: Final = f"{prompt_template}\n\nTitle: {final_title}\n\nContent:\n{content}"
+    try:
+        final_client: Final = get_gemini_client()
+        final_response: Final = final_client.models.generate_content(
+            model=LLM_MODEL,
+            contents=final_full_prompt,
+            config={
+                "response_mime_type": "application/json",
+                "response_schema": {
+                    "type": "object",
+                    "properties": {"result": {"type": "boolean"}},
+                    "required": ["result"],
+                },
+            },
+        )
+        final_parsed: Final = json.loads(final_response.text)
+        return bool(final_parsed.get("result", False))
+    except Exception as exc:
+        logging.exception("LLM check failed: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# General cleaning functions
+# ---------------------------------------------------------------------------
+
+
+def clean_beehiiv_to_plaintext(text: str) -> str:
+    final_html: Final = markdown.markdown(text)
+    final_soup: Final = BeautifulSoup(final_html, features="html.parser")
+    return final_soup.get_text()
+
+
+def clean_beehiiv_emphasis(text: str) -> str:
+    final_without_double: Final = re.sub(r"__([^_]+)__", r"\1", text)
+    return re.sub(r"_([^_]+)_", r"\1", final_without_double)
+
+
+def apply_general_cleaning(
+    text: str,
+    metadata: dict[str, str],
+    config: dict,
+    stats: dict[str, dict],
+) -> str:
+    final_gc_config: Final = config.get("general_cleaning") or {}
+    final_overrides: Final = final_gc_config.get("overrides") or []
+
+    def is_enabled(key: str) -> bool:
+        # Check per-source overrides first
+        for override in final_overrides:
+            if evaluate_match(override["match"], metadata) and key in override:
+                return bool(override[key])
+        # Then global config
+        if key in final_gc_config:
+            return bool(final_gc_config[key])
+        # Default: enabled
+        return True
+
+    def count_and_sub(pattern: str, replacement: str, text: str, key: str, flags: int = 0) -> str:
+        final_matches: Final = len(re.findall(pattern, text, flags=flags))
+        if final_matches > 0:
+            stats[key] = {"matches": final_matches}
+        return re.sub(pattern, replacement, text, flags=flags)
+
+    result: str = text
+
+    # Beehiiv plaintext conversion (must be first — changes text representation)
+    if is_enabled("beehiiv_plaintext_conversion") and metadata.get("source_kind") == "beehiiv":
+        result = clean_beehiiv_to_plaintext(result)
+        stats["beehiiv_plaintext_conversion"] = {"applied": True}
+
+    # Beehiiv emphasis removal (right after plaintext conversion)
+    if is_enabled("beehiiv_emphasis_removal") and metadata.get("source_kind") == "beehiiv":
+        final_before_emphasis: Final = result
+        result = clean_beehiiv_emphasis(result)
+        if result != final_before_emphasis:
+            stats["beehiiv_emphasis_removal"] = {"applied": True}
+
+    # URL removal
+    if is_enabled("url_removal"):
+        result = count_and_sub(
+            r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,5}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)",
+            "",
+            result,
+            "url_removal",
+        )
+
+    # Legal bracket unwrap [t]he -> the
+    if is_enabled("legal_bracket_unwrap"):
+        result = count_and_sub(
+            r"\[([a-zA-Z])\]",
+            r"\1",
+            result,
+            "legal_bracket_unwrap",
+        )
+
+    # Triple dash removal
+    if is_enabled("triple_dash_removal"):
+        result = count_and_sub(r"---+", "", result, "triple_dash_removal")
+
+    # Empty bracket removal
+    if is_enabled("empty_bracket_removal"):
+        final_before_brackets: Final = result
+        result = re.sub(r"\[\]", "", result)
+        result = re.sub(r"\(\)", "", result)
+        result = result.replace("<>", "")
+        final_bracket_diff: Final = len(final_before_brackets) - len(result)
+        if final_bracket_diff > 0:
+            stats["empty_bracket_removal"] = {"chars_removed": final_bracket_diff}
+
+    # Whitespace collapse
+    if is_enabled("whitespace_collapse"):
+        result = re.sub(r"[^\S\r\n]+", " ", result)
+        stats["whitespace_collapse"] = {"applied": True}
+
+    # Unsubscribe removal
+    if is_enabled("unsubscribe_removal"):
+        result = count_and_sub(
+            r"(\r\n|\r|\n){2}Unsubscribe",
+            "",
+            result,
+            "unsubscribe_removal",
+        )
+
+    # View online removal
+    if is_enabled("view_online_removal"):
+        result = count_and_sub(
+            r"View this post on the web at (\r\n|\r|\n){2}",
+            "",
+            result,
+            "view_online_removal",
+        )
+
+    # Substack refs removal
+    if is_enabled("substack_refs_removal"):
+        result = count_and_sub(
+            r"(?im)^\s*substacks referenced above:.*\r?\n(?:\s*@\s*\r?\n)*",
+            "",
+            result,
+            "substack_refs_removal",
+        )
+
+    # Standalone @ removal
+    if is_enabled("standalone_at_removal"):
+        result = count_and_sub(
+            r"(?m)^\s*@\s*$\r?\n?",
+            "",
+            result,
+            "standalone_at_removal",
+        )
+
+    # End-of-line punctuation (must be last)
+    if is_enabled("end_of_line_punctuation"):
+        result = re.sub(r"(\w)\s*(\r\n|\r|\n)", r"\1.\2", result)
+        stats["end_of_line_punctuation"] = {"applied": True}
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# YAML text removals and replacements
+# ---------------------------------------------------------------------------
+
+
+def apply_text_removals(text: str, config: dict, stats: dict[str, dict]) -> str:
+    result: str = text
+    for removal in config.get("text_removals") or []:
+        final_pattern = removal["pattern"]
+        final_flags = parse_flags(removal.get("flags"))
+        final_reason = removal["reason"]
+        final_matches = len(re.findall(final_pattern, result, flags=final_flags))
+        if final_matches > 0:
+            result = re.sub(final_pattern, "", result, flags=final_flags)
+            stats[final_reason] = {"matches": final_matches}
+    return result
+
+
+def apply_text_replacements(text: str, config: dict, stats: dict[str, dict]) -> str:
+    result: str = text
+    for repl in config.get("text_replacements") or []:
+        final_pattern = repl["pattern"]
+        final_replacement = repl["replacement"]
+        final_flags = parse_flags(repl.get("flags"))
+        final_reason = repl["reason"]
+        final_matches = len(re.findall(final_pattern, result, flags=final_flags))
+        if final_matches > 0:
+            result = re.sub(final_pattern, final_replacement, result, flags=final_flags)
+            stats[final_reason] = {"matches": final_matches}
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Stats management
+# ---------------------------------------------------------------------------
+
+
+def load_today_stats() -> dict:
+    final_today: Final = datetime.now().strftime("%Y-%m-%d")
+    final_stats_path: Final = pathlib.Path(STATS_DIR) / f"{final_today}.json"
+    if final_stats_path.exists():
+        return json.loads(final_stats_path.read_text(encoding="utf-8"))
+    return {}
+
+
+def save_stats(stats: dict) -> None:
+    final_today: Final = datetime.now().strftime("%Y-%m-%d")
+    final_stats_path: Final = pathlib.Path(STATS_DIR) / f"{final_today}.json"
+    final_stats_path.parent.mkdir(parents=True, exist_ok=True)
+    final_stats_path.write_text(
+        json.dumps(stats, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def rotate_stats() -> None:
+    final_cutoff: Final = datetime.now() - timedelta(days=STATS_RETENTION_DAYS)
+    final_stats_path: Final = pathlib.Path(STATS_DIR)
+    if not final_stats_path.exists():
+        return
+    for stats_file in final_stats_path.glob("*.json"):
+        try:
+            final_file_date = datetime.strptime(stats_file.stem, "%Y-%m-%d")
+            if final_file_date < final_cutoff:
+                stats_file.unlink()
+                logging.info("Rotated old stats file: %s", stats_file.name)
+        except ValueError:
+            continue
+
+
+# ---------------------------------------------------------------------------
+# File writing helpers
+# ---------------------------------------------------------------------------
+
+
+def write_metadata_and_content(
+    filepath: pathlib.Path,
+    metadata: dict[str, str],
+    content: str,
+) -> None:
+    final_meta_lines: Final = [
+        f"META_{key.upper()}: {value}" for key, value in metadata.items()
+    ]
+    final_meta_block: Final = "\n".join(final_meta_lines)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_text(
+        final_meta_block + "\n\n" + content,
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main processing
+# ---------------------------------------------------------------------------
+
+
+def load_config() -> dict:
+    final_config_path: Final = pathlib.Path(CONFIG_FILE)
+    if not final_config_path.exists():
+        logging.info("No filters.yaml found; using defaults (no filters, no removals)")
+        return {}
+    final_raw: Final = final_config_path.read_text(encoding="utf-8")
+    final_config: Final = yaml.safe_load(final_raw) or {}
+    validate_config(final_config)
+    return final_config
+
+
+def process_file(filepath: pathlib.Path, config: dict, all_stats: dict) -> None:
+    final_filename: Final = filepath.name
+    logging.info("Processing: %s", final_filename)
+
+    # Read and parse
+    final_raw_text: Final = filepath.read_text(encoding="utf-8")
+    final_metadata: dict[str, str]
+    final_metadata, final_content_raw = split_metadata(final_raw_text)
+    final_timestamp: Final = datetime.now().isoformat(timespec="seconds")
+
+    # Initialize stats entry
+    final_file_stats: Final[dict] = {
+        "file": final_filename,
+        "raw_archive": None,
+        "cleaned_archive": None,
+        "filtered_archive": None,
+        "filters_checked": [],
+        "filters_matched": [],
+        "text_removals": {},
+        "text_replacements": {},
+        "general_cleaning": {},
+        "outcome": None,
+        "chars_before": len(final_content_raw),
+        "chars_after": None,
+    }
+
+    # --- Run filters ---
+    final_filters: Final = config.get("filters") or []
+    skip_file: bool = False
+    final_filter_reason: str = ""
+
+    for filt in final_filters:
+        final_reason = filt["reason"]
+        final_action = filt.get("action", "skip")
+
+        if not evaluate_match(filt["match"], final_metadata):
+            final_file_stats["filters_checked"].append(final_reason)
+            continue
+
+        # Match block passed — check LLM if needed
+        if "llm_check" in filt:
+            final_llm_result = evaluate_llm_check(
+                filt["llm_check"],
+                final_metadata,
+                final_content_raw,
+            )
+            if not final_llm_result:
+                final_file_stats["filters_checked"].append(final_reason)
+                continue
+
+        # Filter matched
+        final_file_stats["filters_checked"].append(final_reason)
+        final_file_stats["filters_matched"].append(final_reason)
+
+        if final_action == "notify":
+            final_notify_config = filt["notify"]
+            send_gotify_notification(
+                title=final_notify_config["title"],
+                message=f"{final_filename}\n\n{final_metadata.get('title', '')}",
+                priority=final_notify_config["priority"],
+            )
+            continue
+
+        # action == skip
+        skip_file = True
+        final_filter_reason = final_reason
+        break
+
+    if skip_file:
+        # Write to filtered dir with reason
+        final_filtered_metadata: Final = {**final_metadata, "filtered_reason": final_filter_reason}
+        final_filtered_path: Final = pathlib.Path(FILTERED_DIR) / final_filename
+        write_metadata_and_content(final_filtered_path, final_filtered_metadata, final_content_raw)
+
+        # Archive raw
+        final_raw_archive_path: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
+        final_raw_archive_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(filepath), str(final_raw_archive_path))
+
+        final_file_stats["filtered_archive"] = str(final_filtered_path)
+        final_file_stats["raw_archive"] = str(final_raw_archive_path)
+        final_file_stats["outcome"] = "filtered"
+        final_file_stats["chars_after"] = len(final_content_raw)
+        all_stats[final_timestamp] = final_file_stats
+
+        # Delete raw input
+        filepath.unlink()
+        logging.info("Filtered: %s (reason: %s)", final_filename, final_filter_reason)
+        return
+
+    # --- Apply cleaning ---
+    final_gc_stats: Final[dict[str, dict]] = {}
+    cleaned_text: str = apply_general_cleaning(
+        final_content_raw,
+        final_metadata,
+        config,
+        final_gc_stats,
+    )
+    final_file_stats["general_cleaning"] = final_gc_stats
+
+    # YAML text removals
+    final_removal_stats: Final[dict[str, dict]] = {}
+    cleaned_text = apply_text_removals(cleaned_text, config, final_removal_stats)
+    final_file_stats["text_removals"] = final_removal_stats
+
+    # YAML text replacements
+    final_replacement_stats: Final[dict[str, dict]] = {}
+    cleaned_text = apply_text_replacements(cleaned_text, config, final_replacement_stats)
+    final_file_stats["text_replacements"] = final_replacement_stats
+
+    # Prepend and append author + title
+    final_from_name: Final = final_metadata.get("from", "").strip()
+    final_title: Final = final_metadata.get("title", "").strip()
+    final_header: Final = (
+        (f"{final_from_name}.\n" if final_from_name else "")
+        + (f"{final_title}.\n" if final_title else "")
+    )
+    final_footer: Final = (
+        "\n\n"
+        + (f"{final_from_name}.\n" if final_from_name else "")
+        + (f"{final_title}.\n" if final_title else "")
+    )
+    if final_header:
+        cleaned_text = final_header + "\n" + cleaned_text
+    if final_from_name or final_title:
+        cleaned_text = cleaned_text.rstrip() + final_footer
+
+    # Check too-big
+    if len(cleaned_text) >= CHARACTER_LIMIT:
+        final_toobig_reason: Final = f"Content too large: {len(cleaned_text)} chars (limit: {CHARACTER_LIMIT})"
+        final_filtered_metadata_big: Final = {**final_metadata, "filtered_reason": final_toobig_reason}
+        final_filtered_path_big: Final = pathlib.Path(FILTERED_DIR) / final_filename
+        write_metadata_and_content(final_filtered_path_big, final_filtered_metadata_big, cleaned_text)
+
+        final_raw_archive_path_big: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
+        final_raw_archive_path_big.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(filepath), str(final_raw_archive_path_big))
+
+        final_file_stats["filtered_archive"] = str(final_filtered_path_big)
+        final_file_stats["raw_archive"] = str(final_raw_archive_path_big)
+        final_file_stats["outcome"] = "filtered_too_big"
+        final_file_stats["chars_after"] = len(cleaned_text)
+        all_stats[final_timestamp] = final_file_stats
+
+        filepath.unlink()
+        logging.info("Filtered (too big): %s (%d chars)", final_filename, len(cleaned_text))
+        send_gotify_notification(
+            "Skipping large text-to-speech content",
+            f"{final_filename}: {len(cleaned_text)} chars exceeds {CHARACTER_LIMIT} limit.",
+        )
+        return
+
+    # Check empty
+    if not cleaned_text.strip():
+        final_empty_reason: Final = "Content empty after cleaning"
+        final_filtered_metadata_empty: Final = {**final_metadata, "filtered_reason": final_empty_reason}
+        final_filtered_path_empty: Final = pathlib.Path(FILTERED_DIR) / final_filename
+        write_metadata_and_content(final_filtered_path_empty, final_filtered_metadata_empty, "")
+
+        final_raw_archive_path_empty: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
+        final_raw_archive_path_empty.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(filepath), str(final_raw_archive_path_empty))
+
+        final_file_stats["filtered_archive"] = str(final_filtered_path_empty)
+        final_file_stats["raw_archive"] = str(final_raw_archive_path_empty)
+        final_file_stats["outcome"] = "filtered_empty"
+        final_file_stats["chars_after"] = 0
+        all_stats[final_timestamp] = final_file_stats
+
+        filepath.unlink()
+        logging.info("Filtered (empty after cleaning): %s", final_filename)
+        send_gotify_notification(
+            "Skipping empty text-to-speech content",
+            f"{final_filename}: empty after cleaning.",
+        )
+        return
+
+    # --- Write outputs ---
+    # Write cleaned output
+    final_cleaned_path: Final = pathlib.Path(CLEANED_OUTPUT_DIR) / final_filename
+    write_metadata_and_content(final_cleaned_path, final_metadata, cleaned_text)
+
+    # Archive raw
+    final_raw_archive_final: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
+    final_raw_archive_final.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(str(filepath), str(final_raw_archive_final))
+
+    # Archive cleaned
+    final_cleaned_archive: Final = pathlib.Path(CLEANED_ARCHIVE_DIR) / final_filename
+    final_cleaned_archive.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(str(final_cleaned_path), str(final_cleaned_archive))
+
+    final_file_stats["raw_archive"] = str(final_raw_archive_final)
+    final_file_stats["cleaned_archive"] = str(final_cleaned_archive)
+    final_file_stats["outcome"] = "cleaned"
+    final_file_stats["chars_after"] = len(cleaned_text)
+    all_stats[final_timestamp] = final_file_stats
+
+    # Delete raw input (last step — only after all writes succeeded)
+    filepath.unlink()
+    logging.info(
+        "Cleaned: %s (%d -> %d chars)",
+        final_filename,
+        len(final_content_raw),
+        len(cleaned_text),
+    )
+
+
+def process_files() -> None:
+    # Ensure directories exist
+    for dir_path in (RAW_INPUT_DIR, RAW_ARCHIVE_DIR, CLEANED_OUTPUT_DIR, CLEANED_ARCHIVE_DIR, FILTERED_DIR, STATS_DIR):
+        pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
+
+    # Rotate old stats
+    rotate_stats()
+
+    # Load config
+    final_config: Final = load_config()
+
+    # Validate rule ordering
+    final_filters: Final = final_config.get("filters") or []
+    final_ordering_errors: Final = validate_rule_ordering(final_filters)
+    final_shadowed_matches: Final[list[dict]] = []
+
+    if final_ordering_errors:
+        final_error_msg: Final = "Filter rule ordering issues:\n" + "\n".join(final_ordering_errors)
+        logging.error(final_error_msg)
+        send_gotify_notification(
+            "prepare_text.py: filter rule ordering error",
+            final_error_msg + "\n\nAffected files will be left in text-input-raw/ until this is fixed.",
+            priority=9,
+        )
+        # Collect the match blocks from skip rules that shadow later rules
+        for error in final_ordering_errors:
+            # Extract the index of the skip rule from the error message
+            final_idx_str = error.split("filters[")[1].split("]")[0]
+            final_idx = int(final_idx_str)
+            final_shadowed_matches.append(final_filters[final_idx]["match"])
+
+    # Load today's stats (append to existing if re-run)
+    final_all_stats: Final = load_today_stats()
+
+    # Process files
+    final_txt_files: Final = sorted(pathlib.Path(RAW_INPUT_DIR).glob("*.txt"))
+    for txt_file in final_txt_files:
+        # Check if this file matches a shadowed skip rule
+        if final_shadowed_matches:
+            final_raw_text_check = txt_file.read_text(encoding="utf-8")
+            final_meta_check = split_metadata(final_raw_text_check)[0]
+            final_is_shadowed = any(
+                evaluate_match(match, final_meta_check) for match in final_shadowed_matches
+            )
+            if final_is_shadowed:
+                logging.warning(
+                    "Skipping %s due to rule ordering conflict (left in raw)",
+                    txt_file.name,
+                )
+                continue
+
+        try:
+            process_file(txt_file, final_config, final_all_stats)
+        except Exception:
+            logging.exception("Error processing %s — leaving in raw for retry", txt_file.name)
+            continue
+
+    save_stats(final_all_stats)
+
+
+if __name__ == "__main__":
+    process_files()

--- a/prepare-text/pyproject.toml
+++ b/prepare-text/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "prepare-text"
+version = "0.1.0"
+description = "Text preparation pipeline: filtering, cleaning, and transformation"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "beautifulsoup4>=4.12.3",
+    "google-genai>=1.0.0",
+    "markdown>=3.7",
+    "pyyaml>=6.0",
+    "requests>=2.32.3",
+]
+
+[dependency-groups]
+dev = [
+    "basedpyright>=1.20.0",
+    "ruff>=0.7.0",
+    "types-beautifulsoup4>=4.12.0",
+    "types-pyyaml>=6.0",
+    "types-requests>=2.32.0",
+]
+
+[tool.ruff]
+extend = "../pyproject.toml"
+
+[tool.basedpyright]
+extends = "../pyproject.toml"

--- a/prepare-text/uv.lock
+++ b/prepare-text/uv.lock
@@ -1,0 +1,758 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592 },
+]
+
+[[package]]
+name = "basedpyright"
+version = "1.38.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/a3/20aa7c4e83f2f614e0036300f3c352775dede0655c66814da16c37b661a9/basedpyright-1.38.2.tar.gz", hash = "sha256:b433b2b8ba745ed7520cdc79a29a03682f3fb00346d272ece5944e9e5e5daa92", size = 25277019 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/12/736cab83626fea3fe65cdafb3ef3d2ee9480c56723f2fd33921537289a5e/basedpyright-1.38.2-py3-none-any.whl", hash = "sha256:153481d37fd19f9e3adedc8629d1d071b10c5f5e49321fb026b74444b7c70e24", size = 12312475 },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721 },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684 },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271 },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048 },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529 },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097 },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983 },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519 },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572 },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963 },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361 },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932 },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557 },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762 },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230 },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043 },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446 },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101 },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948 },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422 },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499 },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928 },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302 },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909 },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402 },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780 },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320 },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487 },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049 },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793 },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300 },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244 },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828 },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926 },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650 },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687 },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773 },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013 },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593 },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354 },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480 },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584 },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443 },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437 },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487 },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726 },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/b6/9ee9c1a608916ca5feae81a344dffbaa53b26b90be58cc2159e3332d44ec/charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed97c282ee4f994ef814042423a529df9497e3c666dca19be1d4cd1129dc7ade", size = 280976 },
+    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54", size = 189356 },
+    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467", size = 206369 },
+    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60", size = 203285 },
+    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d", size = 196274 },
+    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e", size = 184715 },
+    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f", size = 193426 },
+    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc", size = 191780 },
+    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95", size = 185805 },
+    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a", size = 208342 },
+    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac", size = 193661 },
+    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1", size = 204819 },
+    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98", size = 198080 },
+    { url = "https://files.pythonhosted.org/packages/56/5a/b8b5a23134978ee9885cee2d6995f4c27cc41f9baded0a9685eabc5338f0/charset_normalizer-3.4.5-cp312-cp312-win32.whl", hash = "sha256:1827734a5b308b65ac54e86a618de66f935a4f63a8a462ff1e19a6788d6c2262", size = 132630 },
+    { url = "https://files.pythonhosted.org/packages/70/53/e44a4c07e8904500aec95865dc3f6464dc3586a039ef0df606eb3ac38e35/charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:728c6a963dfab66ef865f49286e45239384249672cd598576765acc2a640a636", size = 142856 },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/c5628f7cad591b1cf45790b7a61483c3e36cf41349c98af7813c483fd6e8/charset_normalizer-3.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:75dfd1afe0b1647449e852f4fb428195a7ed0588947218f7ba929f6538487f02", size = 132982 },
+    { url = "https://files.pythonhosted.org/packages/f5/48/9f34ec4bb24aa3fdba1890c1bddb97c8a4be1bd84ef5c42ac2352563ad05/charset_normalizer-3.4.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac59c15e3f1465f722607800c68713f9fbc2f672b9eb649fe831da4019ae9b23", size = 280788 },
+    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8", size = 188890 },
+    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d", size = 206136 },
+    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce", size = 202551 },
+    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819", size = 195572 },
+    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d", size = 184438 },
+    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763", size = 193035 },
+    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9", size = 191340 },
+    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c", size = 185464 },
+    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67", size = 208014 },
+    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3", size = 193297 },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf", size = 204321 },
+    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6", size = 197509 },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/c7d9dd1503ffc08950b3260f5d39ec2366dd08254f0900ecbcf3a6197c7c/charset_normalizer-3.4.5-cp313-cp313-win32.whl", hash = "sha256:f1d725b754e967e648046f00c4facc42d414840f5ccc670c5670f59f83693e4f", size = 132284 },
+    { url = "https://files.pythonhosted.org/packages/b9/0f/57072b253af40c8aa6636e6de7d75985624c1eb392815b2f934199340a89/charset_normalizer-3.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:e37bd100d2c5d3ba35db9c7c5ba5a9228cbcffe5c4778dc824b164e5257813d7", size = 142630 },
+    { url = "https://files.pythonhosted.org/packages/31/41/1c4b7cc9f13bd9d369ce3bc993e13d374ce25fa38a2663644283ecf422c1/charset_normalizer-3.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:93b3b2cc5cf1b8743660ce77a4f45f3f6d1172068207c1defc779a36eea6bb36", size = 133254 },
+    { url = "https://files.pythonhosted.org/packages/43/be/0f0fd9bb4a7fa4fb5067fb7d9ac693d4e928d306f80a0d02bde43a7c4aee/charset_normalizer-3.4.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8197abe5ca1ffb7d91e78360f915eef5addff270f8a71c1fc5be24a56f3e4873", size = 280232 },
+    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f", size = 189688 },
+    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4", size = 206833 },
+    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee", size = 202879 },
+    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66", size = 195764 },
+    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362", size = 183728 },
+    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7", size = 192937 },
+    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d", size = 192040 },
+    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6", size = 184107 },
+    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39", size = 208310 },
+    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6", size = 192918 },
+    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94", size = 204615 },
+    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e", size = 197784 },
+    { url = "https://files.pythonhosted.org/packages/c7/5e/1aab5cb737039b9c59e63627dc8bbc0d02562a14f831cc450e5f91d84ce1/charset_normalizer-3.4.5-cp314-cp314-win32.whl", hash = "sha256:ee57b926940ba00bca7ba7041e665cc956e55ef482f851b9b65acb20d867e7a2", size = 133009 },
+    { url = "https://files.pythonhosted.org/packages/40/65/e7c6c77d7aaa4c0d7974f2e403e17f0ed2cb0fc135f77d686b916bf1eead/charset_normalizer-3.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:4481e6da1830c8a1cc0b746b47f603b653dadb690bcd851d039ffaefe70533aa", size = 143511 },
+    { url = "https://files.pythonhosted.org/packages/ba/91/52b0841c71f152f563b8e072896c14e3d83b195c188b338d3cc2e582d1d4/charset_normalizer-3.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:97ab7787092eb9b50fb47fa04f24c75b768a606af1bcba1957f07f128a7219e4", size = 133775 },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455 },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289 },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637 },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742 },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528 },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993 },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855 },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635 },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038 },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181 },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482 },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497 },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819 },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230 },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909 },
+    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287 },
+    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728 },
+    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287 },
+    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291 },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539 },
+    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199 },
+    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131 },
+    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072 },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170 },
+    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741 },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728 },
+    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001 },
+    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637 },
+    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487 },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514 },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349 },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667 },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980 },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143 },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674 },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801 },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755 },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539 },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794 },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160 },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123 },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220 },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050 },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/59/7371175bfd949abfb1170aa076352131d7281bd9449c0f978604fc4431c3/google_auth-2.49.0.tar.gz", hash = "sha256:9cc2d9259d3700d7a257681f81052db6737495a1a46b610597f4b8bafe5286ae", size = 333444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/45/de64b823b639103de4b63dd193480dce99526bd36be6530c2dba85bf7817/google_auth-2.49.0-py3-none-any.whl", hash = "sha256:f893ef7307f19cf53700b7e2f61b5a6affe3aa0edf9943b13788920ab92d8d87", size = 240676 },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ba/0b343b0770d4710ad2979fd9301d7caa56c940174d5361ed4a7cc4979241/google_genai-1.66.0.tar.gz", hash = "sha256:ffc01647b65046bca6387320057aa51db0ad64bcc72c8e3e914062acfa5f7c49", size = 504386 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/dd/403949d922d4e261b08b64aaa132af4e456c3b15c8e2a2d9e6ef693f66e2/google_genai-1.66.0-py3-none-any.whl", hash = "sha256:7f127a39cf695277104ce4091bb26e417c59bb46e952ff3699c3a982d9c474ee", size = 732174 },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008 },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180 },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/05/c75c0940b1ebf82975d14f37176679b6f3229eae8b47b6a70d1e1dae0723/nodejs_wheel_binaries-24.14.0.tar.gz", hash = "sha256:c87b515e44b0e4a523017d8c59f26ccbd05b54fe593338582825d4b51fc91e1c", size = 8057 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/8c/b057c2db3551a6fe04e93dd14e33d810ac8907891534ffcc7a051b253858/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:59bb78b8eb08c3e32186da1ef913f1c806b5473d8bd0bb4492702092747b674a", size = 54798488 },
+    { url = "https://files.pythonhosted.org/packages/30/88/7e1b29c067b6625c97c81eb8b0ef37cf5ad5b62bb81e23f4bde804910ec9/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:348fa061b57625de7250d608e2d9b7c4bc170544da7e328325343860eadd59e5", size = 54972803 },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/a83f0ff12faca2a56366462e572e38ac6f5cb361877bb29e289138eb7f24/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:222dbf516ccc877afcad4e4789a81b4ee93daaa9f0ad97c464417d9597f49449", size = 59340859 },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/06fad4ae8a723ae7096b5311eba67ad8b4df5f359c0a68e366750b7fef78/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b35d6fcccfe4fb0a409392d237fbc67796bac0d357b996bc12d057a1531a238b", size = 59838751 },
+    { url = "https://files.pythonhosted.org/packages/8c/72/4916dadc7307c3e9bcfa43b4b6f88237932d502c66f89eb2d90fb07810db/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:519507fb74f3f2b296ab1e9f00dcc211f36bbfb93c60229e72dcdee9dafd301a", size = 61340534 },
+    { url = "https://files.pythonhosted.org/packages/2e/df/a8ba881ee5d04b04e0d93abc8ce501ff7292813583e97f9789eb3fc0472a/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:68c93c52ff06d704bcb5ed160b4ba04ab1b291d238aaf996b03a5396e0e9a7ed", size = 61922394 },
+    { url = "https://files.pythonhosted.org/packages/60/8c/b8c5f61201c72a0c7dc694b459941f89a6defda85deff258a9940a4e2efc/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:60b83c4e98b0c7d836ac9ccb67dcb36e343691cbe62cd325799ff9ed936286f3", size = 41218783 },
+    { url = "https://files.pythonhosted.org/packages/91/23/1f904bc9cbd8eece393e20840c08ba3ac03440090c3a4e95168fa6d2709f/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:78a9bd1d6b11baf1433f9fb84962ff8aa71c87d48b6434f98224bc49a2253a6e", size = 38926103 },
+]
+
+[[package]]
+name = "prepare-text"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "google-genai" },
+    { name = "markdown" },
+    { name = "pyyaml" },
+    { name = "requests" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "basedpyright" },
+    { name = "ruff" },
+    { name = "types-beautifulsoup4" },
+    { name = "types-pyyaml" },
+    { name = "types-requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12.3" },
+    { name = "google-genai", specifier = ">=1.0.0" },
+    { name = "markdown", specifier = ">=3.7" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "requests", specifier = ">=2.32.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright", specifier = ">=1.20.0" },
+    { name = "ruff", specifier = ">=0.7.0" },
+    { name = "types-beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
+    { name = "types-requests", specifier = ">=2.32.0" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371 },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259 },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172 },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990 },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003 },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200 },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578 },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504 },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816 },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366 },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698 },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603 },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591 },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068 },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908 },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145 },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179 },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403 },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206 },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307 },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258 },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917 },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186 },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164 },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146 },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788 },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133 },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852 },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679 },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766 },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005 },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622 },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725 },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040 },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691 },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897 },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302 },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877 },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680 },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960 },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102 },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039 },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126 },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489 },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288 },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255 },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760 },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092 },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385 },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832 },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585 },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078 },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914 },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560 },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244 },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955 },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906 },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607 },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769 },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441 },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291 },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632 },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905 },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495 },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388 },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879 },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063 },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116 },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011 },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870 },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089 },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181 },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658 },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003 },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344 },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669 },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252 },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081 },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159 },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626 },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613 },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115 },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427 },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090 },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246 },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814 },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809 },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355 },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175 },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194 },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429 },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912 },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108 },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641 },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901 },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132 },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261 },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272 },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062 },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341 },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738 },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9b/840e0039e65fcf12758adf684d2289024d6140cde9268cc59887dc55189c/ruff-0.15.5.tar.gz", hash = "sha256:7c3601d3b6d76dce18c5c824fc8d06f4eef33d6df0c21ec7799510cde0f159a2", size = 4574214 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/20/5369c3ce21588c708bcbe517a8fbe1a8dfdb5dfd5137e14790b1da71612c/ruff-0.15.5-py3-none-linux_armv6l.whl", hash = "sha256:4ae44c42281f42e3b06b988e442d344a5b9b72450ff3c892e30d11b29a96a57c", size = 10478185 },
+    { url = "https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080", size = 10859201 },
+    { url = "https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010", size = 10184752 },
+    { url = "https://files.pythonhosted.org/packages/66/0e/ba49e2c3fa0395b3152bad634c7432f7edfc509c133b8f4529053ff024fb/ruff-0.15.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba786a8295c6574c1116704cf0b9e6563de3432ac888d8f83685654fe528fd65", size = 10534857 },
+    { url = "https://files.pythonhosted.org/packages/59/71/39234440f27a226475a0659561adb0d784b4d247dfe7f43ffc12dd02e288/ruff-0.15.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd4b801e57955fe9f02b31d20375ab3a5c4415f2e5105b79fb94cf2642c91440", size = 10309120 },
+    { url = "https://files.pythonhosted.org/packages/f5/87/4140aa86a93df032156982b726f4952aaec4a883bb98cb6ef73c347da253/ruff-0.15.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391f7c73388f3d8c11b794dbbc2959a5b5afe66642c142a6effa90b45f6f5204", size = 11047428 },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/4953e7e3287676f78fbe85e3a0ca414c5ca81237b7575bdadc00229ac240/ruff-0.15.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dc18f30302e379fe1e998548b0f5e9f4dff907f52f73ad6da419ea9c19d66c8", size = 11914251 },
+    { url = "https://files.pythonhosted.org/packages/77/46/0f7c865c10cf896ccf5a939c3e84e1cfaeed608ff5249584799a74d33835/ruff-0.15.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc6e7f90087e2d27f98dc34ed1b3ab7c8f0d273cc5431415454e22c0bd2a681", size = 11333801 },
+    { url = "https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a", size = 11206821 },
+    { url = "https://files.pythonhosted.org/packages/7a/0d/2132ceaf20c5e8699aa83da2706ecb5c5dcdf78b453f77edca7fb70f8a93/ruff-0.15.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9b037924500a31ee17389b5c8c4d88874cc6ea8e42f12e9c61a3d754ff72f1ca", size = 11133326 },
+    { url = "https://files.pythonhosted.org/packages/72/cb/2e5259a7eb2a0f87c08c0fe5bf5825a1e4b90883a52685524596bfc93072/ruff-0.15.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:65bb414e5b4eadd95a8c1e4804f6772bbe8995889f203a01f77ddf2d790929dd", size = 10510820 },
+    { url = "https://files.pythonhosted.org/packages/ff/20/b67ce78f9e6c59ffbdb5b4503d0090e749b5f2d31b599b554698a80d861c/ruff-0.15.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d20aa469ae3b57033519c559e9bc9cd9e782842e39be05b50e852c7c981fa01d", size = 10302395 },
+    { url = "https://files.pythonhosted.org/packages/5f/e5/719f1acccd31b720d477751558ed74e9c88134adcc377e5e886af89d3072/ruff-0.15.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:15388dd28c9161cdb8eda68993533acc870aa4e646a0a277aa166de9ad5a8752", size = 10754069 },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/d1db14469e32d98f3ca27079dbd30b7b44dbb5317d06ab36718dee3baf03/ruff-0.15.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b30da330cbd03bed0c21420b6b953158f60c74c54c5f4c1dabbdf3a57bf355d2", size = 11304315 },
+    { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676 },
+    { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972 },
+    { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572 },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016 },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926 },
+]
+
+[[package]]
+name = "types-beautifulsoup4"
+version = "4.12.0.20250516"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-html5lib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/d1/32b410f6d65eda94d3dfb0b3d0ca151f12cb1dc4cef731dcf7cbfd8716ff/types_beautifulsoup4-4.12.0.20250516.tar.gz", hash = "sha256:aa19dd73b33b70d6296adf92da8ab8a0c945c507e6fb7d5db553415cc77b417e", size = 16628 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/79/d84de200a80085b32f12c5820d4fd0addcbe7ba6dce8c1c9d8605e833c8e/types_beautifulsoup4-4.12.0.20250516-py3-none-any.whl", hash = "sha256:5923399d4a1ba9cc8f0096fe334cc732e130269541d66261bb42ab039c0376ee", size = 16879 },
+]
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.20251117"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/f3/d9a1bbba7b42b5558a3f9fe017d967f5338cf8108d35991d9b15fdea3e0d/types_html5lib-1.1.11.20251117.tar.gz", hash = "sha256:1a6a3ac5394aa12bf547fae5d5eff91dceec46b6d07c4367d9b39a37f42f201a", size = 18100 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ab/f5606db367c1f57f7400d3cb3bead6665ee2509621439af1b29c35ef6f9e/types_html5lib-1.1.11.20251117-py3-none-any.whl", hash = "sha256:2a3fc935de788a4d2659f4535002a421e05bea5e172b649d33232e99d4272d08", size = 24302 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338 },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20260107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676 },
+]
+
+[[package]]
+name = "types-webencodings"
+version = "0.5.0.20251108"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/d6/75e381959a2706644f02f7527d264de3216cf6ed333f98eff95954d78e07/types_webencodings-0.5.0.20251108.tar.gz", hash = "sha256:2378e2ceccced3d41bb5e21387586e7b5305e11519fc6b0659c629f23b2e5de4", size = 7470 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/4e/8fcf33e193ce4af03c19d0e08483cf5f0838e883f800909c6bc61cb361be/types_webencodings-0.5.0.20251108-py3-none-any.whl", hash = "sha256:e21f81ff750795faffddaffd70a3d8bfff77d006f22c27e393eb7812586249d8", size = 8715 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365 },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038 },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915 },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152 },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583 },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880 },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261 },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693 },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364 },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039 },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323 },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975 },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203 },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653 },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920 },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255 },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689 },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406 },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085 },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044 },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279 },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711 },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982 },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915 },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381 },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737 },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268 },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486 },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331 },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501 },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062 },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356 },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085 },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531 },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
+]

--- a/process.sh
+++ b/process.sh
@@ -34,17 +34,14 @@ echo "Main--Ensure Playwright is up to date"
 /home/flog99/.local/bin/uv run playwright install
 echo "Main--Run Parse RSS script"
 /home/flog99/.local/bin/uv run python3 check-rss.py
-cd ..
+cd /home/flog99/dev/podcast-transcribe/prepare-text
+echo "Main--Install Prepare Text dependencies"
+/home/flog99/.local/bin/uv sync
+echo "Main--Run Prepare Text script"
+/home/flog99/.local/bin/uv run python3 prepare_text.py
+cd /home/flog99/dev/podcast-transcribe
 export GOOGLE_APPLICATION_CREDENTIALS=/home/flog99/dev/podcast-transcribe/EmailPodcast-c69d63681230.json
-echo "Main--Archive a copy of input text files"
-mkdir -p text-to-speech/input-text-archive
-if compgen -G "text-to-speech/text-input/*.txt" > /dev/null; then
-    cp --update=none text-to-speech/text-input/*.txt text-to-speech/input-text-archive/
-fi
 cd text-to-speech
-echo "Main--Remove empty text files"
-mkdir -p ./text-input-empty-files
-find ./text-input -size 0 -exec  mv {}  ./text-input-empty-files/ \;
 echo "Main--Install Google Text to Speech dependencies"
 /home/flog99/.local/bin/uv sync
 echo "Main--Run Google Text to Speech script"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-line-length = 88
+line-length = 120
 target-version = "py312"
 
 [tool.ruff.lint]

--- a/rss/check-rss.py
+++ b/rss/check-rss.py
@@ -13,9 +13,7 @@ import requests
 import urllib3
 from bs4 import BeautifulSoup
 from dateutil import parser
-from google import genai
 from playwright.sync_api import sync_playwright
-from pydantic import BaseModel
 from requests.adapters import HTTPAdapter
 from trafilatura import bare_extraction, extract
 from urllib3.util.retry import Retry
@@ -24,9 +22,6 @@ from waybackpy.exceptions import MaximumSaveRetriesExceeded, TooManyRequestsErro
 
 local_scraper_url = "http://localhost:3002/fetch"
 bill_simmons_feed = "https://feeds.megaphone.fm/the-bill-simmons-podcast"
-summary_model = "gemini-3.1-flash-lite-preview"
-_gemini_client = None
-
 # Create a Retry object with zero retries
 retry_strategy = Retry(
     total=0,  # Total number of retries to allow
@@ -43,7 +38,7 @@ enable_diagnosis = False
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-output_folder = "../text-to-speech/text-input"
+output_folder = "../prepare-text/text-input-raw"
 feedsFile = "feeds.txt"
 wayback_feeds = [
     "https://www.nytimes.com/svc/collections/v1/publish/www.nytimes.com/column/ross-douthat/rss.xml",
@@ -52,13 +47,6 @@ wayback_feeds = [
 ]
 
 feeds = [line.rstrip() for line in pathlib.Path(feedsFile).open(encoding="utf-8")]
-
-
-def get_gemini_client():
-    global _gemini_client
-    if _gemini_client is None:
-        _gemini_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-    return _gemini_client
 
 
 def send_gotify_notification(title, message, priority=6) -> None:
@@ -70,30 +58,6 @@ def send_gotify_notification(title, message, priority=6) -> None:
     gotify_url = f"{gotify_server}/message?token={gotify_token}"
     data = {"title": title, "message": message, "priority": priority}
     requests.post(gotify_url, data=data)
-
-
-def is_nfl_related(title, description):
-    if not title and not description:
-        return False
-
-    class NflCheck(BaseModel):
-        is_nfl: bool
-
-    prompt = f"Determine if this podcast episode involves NFL football.\n\nTitle: {title}\n\nDescription:\n{description}"
-    try:
-        client = get_gemini_client()
-        response = client.models.generate_content(
-            model=summary_model,
-            contents=prompt,
-            config={
-                "response_mime_type": "application/json",
-                "response_schema": NflCheck,
-            },
-        )
-        return response.parsed.is_nfl
-    except Exception as exc:
-        logging.exception("NFL relevance check failed: %s", exc)
-        return False
 
 
 def get_entry_link(entry):
@@ -280,7 +244,6 @@ for feed in feeds:
             output_filename = f"{output_folder}/{date_stamp}-{feed_prefix_for_filename}{entry_title_for_filename}.txt"
             meta_title = entry_title_raw
             original_url = get_entry_link(parsed_feed_entry)
-            write_output = True
 
             if feed == bill_simmons_feed:
                 entry_description_raw = (
@@ -288,19 +251,7 @@ for feed in feeds:
                     or parsed_feed_entry.get("description")
                     or ""
                 )
-                entry_description = str(entry_description_raw)
-                if is_nfl_related(entry_title_raw, entry_description):
-                    notify_title = (
-                        f"New Bill Simmons podcast to whitelist: {entry_title_raw}"
-                    )
-                    notify_description = f"https://podly.klt.pw\n\n{entry_description}"
-                    send_gotify_notification(
-                        notify_title,
-                        notify_description,
-                        priority=9,
-                    )
-                content_text = ""
-                write_output = False
+                content_text = str(entry_description_raw)
             elif feed in wayback_feeds:
                 try:
                     send_error_with_gotify = False
@@ -460,28 +411,20 @@ for feed in feeds:
                     break
             else:
                 soup = BeautifulSoup(parsed_feed_entry.content[0].value, "html.parser")
-                content_text_raw = soup.get_text()
-                content_text_with_prefix = (
-                    (feed_title_raw + ".\n" if feed_title_raw else "")
-                    + entry_title_raw
-                    + ".\n"
-                    + "\n"
-                    + content_text_raw
-                )
-                content_text = content_text_with_prefix
-            if write_output:
-                output_file = pathlib.Path(output_filename).open("w", encoding="utf-8")
-                metadata_block = "\n".join(
-                    [
-                        f"META_FROM: {feed_title_raw}",
-                        f"META_TITLE: {meta_title}",
-                        f"META_SOURCE_URL: {original_url}",
-                        "META_SOURCE_KIND: rss",
-                    ],
-                )
-                logging.info("Writing metadata block to text input")
-                output_file.write(metadata_block + "\n\n" + content_text)
-                output_file.close()
+                content_text = soup.get_text()
+            output_file = pathlib.Path(output_filename).open("w", encoding="utf-8")
+            metadata_block = "\n".join(
+                [
+                    f"META_FROM: {feed_title_raw}",
+                    f"META_TITLE: {meta_title}",
+                    f"META_SOURCE_URL: {original_url}",
+                    "META_SOURCE_KIND: rss",
+                    "META_INTAKE_TYPE: rss",
+                ],
+            )
+            logging.info("Writing raw metadata and text to text input")
+            output_file.write(metadata_block + "\n\n" + content_text)
+            output_file.close()
             guidDirExists = pathlib.Path(guid_dir).exists()
             if not guidDirExists:
                 pathlib.Path(guid_dir).mkdir(parents=True)

--- a/text-to-speech/text_to_speech.py
+++ b/text-to-speech/text_to_speech.py
@@ -5,107 +5,22 @@ import operator
 import os
 import pathlib
 import re
-import shutil
 import uuid
 from datetime import datetime
 from glob import glob
 
-import requests
+from google import genai
 from google.cloud import texttospeech
 from mutagen.id3 import ID3, TIT2, TT3, WXXX, ID3NoHeaderError
-from google import genai
 from pydub import AudioSegment
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-input_dir = "text-input"
+input_dir = "../prepare-text/text-input-cleaned"
 temp_output_dir = "temp-output"
 final_output_dir = "../dropcaster-docker/audio"
-character_limit = 150000
 summary_model = "gemini-3.1-flash-lite-preview"
 _gemini_client = None
-
-
-# Using regular expressions to clean email text
-def clean_text(text):
-    text_raw = "".join(text)
-    # Remove three or more consecutive dashes
-    text_without_dashes = re.sub(r"---+", "", text_raw)
-    # Remove URLs from the email text
-    text_without_urls = re.sub(
-        r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,5}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)",
-        "",
-        text_without_dashes,
-    )
-    # Unwrap legal-citation brackets e.g. [t]he -> the, [T]he -> The
-    text_without_legal_brackets = re.sub(r"\[([a-zA-Z])\]", r"\1", text_without_urls)
-    # Remove empty square brackets []
-    text_without_empty_brackets = re.sub(r"\[\]", "", text_without_legal_brackets)
-    # Remove empty parentheses ()
-    text_without_empty_parens = re.sub(r"\(\)", "", text_without_empty_brackets)
-    # Remove empty angle brackets <>
-    text_without_empty_angles = text_without_empty_parens.replace(r"<>", "")
-    # get rid of superfluous non-newline whitespace
-    text_without_extra_whitespace = re.sub(
-        r"[^\S\r\n]+",
-        " ",
-        text_without_empty_angles,
-    )
-    # get rid of unsubscribe text
-    text_without_unsubscribe = re.sub(
-        r"(\r\n|\r|\n){2}Unsubscribe",
-        "",
-        text_without_extra_whitespace,
-    )
-    # get rid of intro 'view this post on the web' text
-    text_without_view_online = re.sub(
-        r"View this post on the web at (\r\n|\r|\n){2}",
-        "",
-        text_without_unsubscribe,
-    )
-    # remove Substack "substacks referenced above" block and trailing @ lines
-    text_without_substack_refs = re.sub(
-        r"(?im)^\s*substacks referenced above:.*\r?\n(?:\s*@\s*\r?\n)*",
-        "",
-        text_without_view_online,
-    )
-    # remove any leftover standalone @ lines
-    text_without_at_lines = re.sub(
-        r"(?m)^\s*@\s*$\r?\n?",
-        "",
-        text_without_substack_refs,
-    )
-    # get rid of plain text disclaimer on beehiiv emails
-    text_without_plain_text_disclaimer = re.sub(
-        r"You are reading a plain text version of this post. For the best experience, copy and paste this link in your browser to view the post online:",
-        "",
-        text_without_at_lines,
-    )
-    # get rid of social links at top of Money Illusion posts
-    text_without_social_links = re.sub(
-        r"Facebook *(\r\n|\r|\n)Twitter *(\r\n|\r|\n)LinkedIn *(\r\n|\r|\n)",
-        "",
-        text_without_plain_text_disclaimer,
-    )
-    # get rid of weird image data/captions in beehiiv emails
-    text_without_image_captions = re.sub(
-        r"View image: \(.*?\)(\r\n|\r|\n)?\s*Caption: .*?\s*.*(\r\n|\r|\n)?",
-        "",
-        text_without_social_links,
-    )
-    # fix pronunciation of Keynesian
-    text_with_pronunciation_fix = re.sub(
-        r"Keynesian",
-        "Cainzeean",
-        text_without_image_captions,
-        flags=re.IGNORECASE,
-    )
-    # add punctuation to end of lines without it so that narration pauses briefly
-    return re.sub(
-        r"(\w)\s*(\r\n|\r|\n)",
-        r"\1.\2",
-        text_with_pronunciation_fix,
-    )
 
 
 def split_metadata(raw_text):
@@ -130,7 +45,7 @@ def split_metadata(raw_text):
                 f"{metadata.get(current_key, '')} {line.strip()}".strip()
             )
             continue
-        if line.strip() == "":
+        if not line.strip():
             content_start = idx + 1
             break
         content_start = idx
@@ -168,10 +83,21 @@ def generate_summary(text, title):
         return ""
 
 
-def build_description(summary, title, source_url, source_kind, source_name=""):
+INTAKE_TYPE_LABELS = {
+    "email": "Email",
+    "rss": "RSS",
+    "link": "Link",
+    "youtube": "YouTube",
+}
+
+
+def build_description(summary, title, source_url, source_kind, source_name="", intake_type=""):
     description_body = summary or "Summary unavailable."
     title_line = title or "Untitled"
     parts = [description_body, f"Title: {title_line}"]
+    if intake_type:
+        intake_label = INTAKE_TYPE_LABELS.get(intake_type, intake_type)
+        parts.append(f"Via: {intake_label}")
     if source_url:
         display_text = source_url
         if source_kind == "beehiiv" and source_name:
@@ -218,8 +144,7 @@ def text_to_speech(incoming_filename) -> None:
         name = pathlib.Path(filename.name).name.replace(".txt", "")
         data = filename.read()
         input_text_raw = data.decode("utf8")
-        metadata, content_text_raw = split_metadata(input_text_raw)
-        content_text_cleaned = clean_text(content_text_raw)
+        metadata, content_text = split_metadata(input_text_raw)
         # initialize the API client
         client = texttospeech.TextToSpeechClient()
         mp3files = []
@@ -229,31 +154,30 @@ def text_to_speech(incoming_filename) -> None:
         compiled_regex_for_first_whitespace = re.compile(r"(\r\n|\r|\n|\.)+\s+")
         next_text_starter_position = 0
         counter = 0
-        max_steps = math.floor(1 + len(content_text_cleaned) / min_step_size)
-        if (
-            len(content_text_cleaned) < character_limit
-            and len(content_text_cleaned) > 0
-        ):
+        max_steps = math.floor(1 + len(content_text) / min_step_size)
+        if len(content_text) > 0:
             meta_from = metadata.get("from", "").strip()
             meta_title = metadata.get("title", "").strip()
             meta_source_url = metadata.get("source_url", "").strip()
             meta_source_kind = metadata.get("source_kind", "").strip()
             meta_source_name = metadata.get("source_name", "").strip()
+            meta_intake_type = metadata.get("intake_type", "").strip()
             if meta_title or meta_source_url:
                 logging.info("Using metadata for summary and description")
-            summary = generate_summary(content_text_cleaned, meta_title)
+            summary = generate_summary(content_text, meta_title)
             description = build_description(
                 summary,
                 meta_title,
                 meta_source_url,
                 meta_source_kind,
                 meta_source_name,
+                meta_intake_type,
             )
-            while next_text_starter_position < len(content_text_cleaned):
+            while next_text_starter_position < len(content_text):
                 counter += 1
                 first_whitespace_after_min_step_size_search = (
                     compiled_regex_for_first_whitespace.search(
-                        content_text_cleaned,
+                        content_text,
                         next_text_starter_position + min_step_size,
                         next_text_starter_position + max_step_size,
                     )
@@ -266,11 +190,11 @@ def text_to_speech(incoming_filename) -> None:
                     first_whitespace_after_min_step_size = (
                         next_text_starter_position + max_step_size
                     )
-                    if first_whitespace_after_min_step_size < len(content_text_cleaned):
+                    if first_whitespace_after_min_step_size < len(content_text):
                         logging.info(
                             f"max_step_size met before end of email {filename.name}",
                         )
-                text_to_process = content_text_cleaned[
+                text_to_process = content_text[
                     next_text_starter_position:first_whitespace_after_min_step_size
                 ]
                 next_text_starter_position = first_whitespace_after_min_step_size
@@ -342,66 +266,9 @@ def text_to_speech(incoming_filename) -> None:
 
             logging.info("Removing original text file")
             pathlib.Path(incoming_filename).unlink()
-        elif len(content_text_cleaned) == 0:
+        else:
             logging.warning(
-                f"Skipping {filename.name}: file is empty after cleaning.",
-            )
-            gotify_server = os.environ.get("GOTIFY_SERVER")
-            gotify_token = os.environ.get("GOTIFY_TOKEN")
-            if gotify_server and gotify_token:
-                debug_message = "Skipping empty text-to-speech content"
-                debug_output = (
-                    f"Skipping {filename.name}: file is empty after cleaning. "
-                    "Moving to holding directory."
-                )
-                gotify_url = f"{gotify_server}/message?token={gotify_token}"
-                data = {
-                    "title": debug_message,
-                    "message": debug_output,
-                    "priority": 6,
-                }
-                requests.post(gotify_url, data=data)
-            else:
-                logging.warning("Gotify env vars not set; skipping notification.")
-
-            # Move the file to a separate directory so the processing isn't repeatedly tried
-            parent = pathlib.Path(pathlib.Path(input_dir).resolve()).parent
-            target_dir = os.path.join(parent, "text-input-empty-after-cleaning")
-            pathlib.Path(target_dir).mkdir(exist_ok=True, parents=True)
-
-            shutil.move(
-                incoming_filename,
-                os.path.join(target_dir, pathlib.Path(incoming_filename).name),
-            )
-            logging.info(
-                "Moved empty-after-cleaning file to %s",
-                target_dir,
-            )
-        elif len(content_text_cleaned) >= character_limit:
-            logging.warning(
-                f"Skipping {filename.name}: text length {len(content_text_cleaned)} exceeds {character_limit} character limit.",
-            )
-            gotify_server = os.environ.get("GOTIFY_SERVER")
-            gotify_token = os.environ.get("GOTIFY_TOKEN")
-            debug_message = "Skipping long text-to-speech content"
-            debug_output = f"Skipping {filename.name}: text length {len(content_text_cleaned)} exceeds {character_limit} character limit. Moving to holding directory."
-
-            gotify_url = f"{gotify_server}/message?token={gotify_token}"
-            data = {
-                "title": debug_message,
-                "message": debug_output,
-                "priority": 6,
-            }
-            requests.post(gotify_url, data=data)
-
-            # Move the file to a separate directory so the processing isn't repeatedly tried
-            parent = pathlib.Path(pathlib.Path(input_dir).resolve()).parent
-            target_dir = os.path.join(parent, "text-input-too-big")
-            pathlib.Path(target_dir).mkdir(exist_ok=True, parents=True)
-
-            shutil.move(
-                incoming_filename,
-                os.path.join(target_dir, pathlib.Path(incoming_filename).name),
+                f"Skipping {filename.name}: file has no content.",
             )
 
 


### PR DESCRIPTION
## Summary

Extracts all filtering, text cleaning, and text transformation from the intake scripts (imap, rss) and TTS into a new dedicated `prepare-text/prepare_text.py` script with YAML-driven configuration.

- **New `prepare-text/prepare_text.py`** — Centralized preprocessing step that runs between intake and TTS. Handles YAML-configured filter rules (skip/notify actions, LLM-based checks), general cleaning (URL removal, whitespace collapse, unsubscribe stripping, end-of-line punctuation, etc.), regex text removals, and regex text replacements (pronunciation fixes). Includes rule ordering validation with Gotify alerts, atomic per-file processing, and daily JSON stats with 12-month retention.
- **New `prepare-text/filters.example.yaml`** — Schema documentation with generic examples for all filter types, text removals, text replacements, and general cleaning overrides.
- **Simplified intake scripts** — `imap/parse_email.py` and `rss/check-rss.py` stripped down to raw content writers. All transformation logic removed; now just emit raw text with `META_INTAKE_TYPE` header to `prepare-text/text-input-raw/`.
- **Simplified TTS** — `text-to-speech/text_to_speech.py` no longer cleans text. Reads pre-cleaned content from `prepare-text/text-input-cleaned/`. Added "Via: {type}" labels in episode descriptions.
- **Updated `process.sh`** — New prepare-text step between RSS and TTS. Removed archive copy and empty file move steps (now handled by prepare_text.py).
- **Line length bumped** from 88 to 120 in root `pyproject.toml`.

### Pipeline flow (updated)
```
imap/parse_email.py → rss/check-rss.py → prepare-text/prepare_text.py → text-to-speech/text_to_speech.py → dropcaster
     (raw email)          (raw RSS)            (filter + clean)                (TTS + MP3)                   (RSS feed)
```

### Directory layout (new)
```
prepare-text/
  prepare_text.py              # preprocessing script
  filters.yaml                 # gitignored — user's active config
  filters.example.yaml         # checked in — documents schema
  stats/                       # gitignored — daily JSON logs
  text-input-raw/              # intake scripts write here
  text-input-raw-archive/      # permanent archive of originals
  text-input-cleaned/          # output for TTS
  text-input-cleaned-archive/  # permanent archive of cleaned versions
  text-input-filtered/         # files that hit a filter (with META_FILTERED_REASON)
```

### Stats
Running in production since commit. Daily JSON stats confirm articles processing correctly with all filter checks, text removals, and char count tracking working as expected.

## Test plan
- [x] Pipeline running in production every 20 minutes via cron — verified via `process-log.log`
- [x] Daily JSON stats in `prepare-text/stats/` confirm correct filtering, cleaning, and archiving
- [x] Verified 3 articles processed across 2 days with expected filter checks and text removals
- [x] No errors in process log since deployment

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)