### PR TITLE
Add lint fixes, immutability, tests, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        subproject: [prepare-text, imap, rss, text-to-speech]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.subproject }}
+        run: uv sync
+
+      - name: Ruff check
+        working-directory: ${{ matrix.subproject }}
+        run: uv run ruff check .
+
+      - name: Ruff format
+        working-directory: ${{ matrix.subproject }}
+        run: uv run ruff format --check .
+
+      - name: Basedpyright
+        working-directory: ${{ matrix.subproject }}
+        run: uv run basedpyright
+
+      - name: Pytest
+        working-directory: ${{ matrix.subproject }}
+        run: uv run pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__/
 /nginx-proxy-certbot-docker/acme/
 /nginx-proxy-certbot-docker/certs/
 /nginx-proxy-certbot-docker/html/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Root `pyproject.toml` defines shared ruff + basedpyright config. Subproject `pyp
 
 5. **text-to-speech/text_to_speech.py** — Reads `text-to-speech/text-input/*.txt`, parses metadata headers (`META_FROM`, `META_TITLE`, `META_SOURCE_URL`, `META_SOURCE_KIND`, `META_SOURCE_NAME`), cleans text aggressively, chunks into 3-5k char segments, calls Google Cloud TTS (en-US-Wavenet-F), stitches MP3 chunks with pydub, generates Gemini summary, writes ID3 tags. Output goes to `dropcaster-docker/audio/`.
 
-5. **Dropcaster** (Docker) regenerates `index.rss` when audio files change. Audio older than 8 weeks is archived.
+6. **Dropcaster** (Docker) regenerates `index.rss` when audio files change. Audio older than 8 weeks is archived.
 
 **Email filters** in `parse_email.py` (set `move_to_podcast = False` to skip):
 - Jessica Valenti: skip unless subject contains "the week in"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,34 +8,44 @@ Converts incoming emails (Substack/Beehiiv newsletters, links, YouTube) and RSS 
 
 ## Commands
 
-Each subproject (imap/, rss/, text-to-speech/) is an independent uv-managed Python project. Always `cd` into the subproject directory first.
+Each subproject (imap/, prepare-text/, rss/, text-to-speech/) is an independent uv-managed Python project. Always `cd` into the subproject directory first.
 
 ```bash
 # Install deps
 cd imap && uv sync
+cd prepare-text && uv sync
 cd rss && uv sync
 cd text-to-speech && uv sync
 
 # Run scripts
 cd imap && uv run python3 parse_email.py
+cd prepare-text && uv run python3 prepare_text.py
 cd rss && uv run python3 check-rss.py
 cd text-to-speech && uv run python3 text_to_speech.py
 
-# Lint (from any subproject dir, or root for shared config)
+# Lint (from any subproject dir)
 uv run ruff check .
 uv run ruff check --fix .
 
+# Format check (from any subproject dir)
+uv run ruff format --check .
+
 # Type check (from subproject dir)
 uv run basedpyright
+
+# Tests (from subproject dir)
+uv run pytest -v
 ```
 
-There are no tests. Validation is manual.
+Unit tests exist for all four subprojects (`test_*.py` files). CI runs pytest, ruff check, ruff format, and basedpyright on every PR and push to main.
 
 ## Linting and type checking
 
 Root `pyproject.toml` defines shared ruff + basedpyright config. Subproject `pyproject.toml` files extend it.
 
-- **ruff**: ALL rules enabled except D (docstrings) and CPY (copyright). Preview mode on. Line length 88. Target Python 3.12.
+- **ruff**: ALL rules enabled except D (docstrings), CPY (copyright), PLR0914 (too many locals), LOG015 (root logger), COM812 (trailing comma — conflicts with ruff format), FBT003 (boolean positional default). Preview mode on. Line length 120. Target Python 3.12.
+- **ruff complexity limits**: max-complexity 35, max-branches 30, max-statements 120.
+- **ruff per-file ignores for tests**: S101, PLR6301, PLC2701, ANN, PLR2004.
 - **basedpyright**: `typeCheckingMode = "all"`, Python 3.12.8.
 
 ## Architecture
@@ -49,9 +59,11 @@ Root `pyproject.toml` defines shared ruff + basedpyright config. Subproject `pyp
 
 2. **rss/check-rss.py** — Polls feeds from `rss/feeds.txt`. NYT feeds use local scraper at `localhost:3002` with Wayback Machine fallback. Bill Simmons feed uses Gemini to detect/skip NFL episodes. GUIDs tracked in `rss/feed-guids/`.
 
-3. **process.sh** archives text inputs to `text-to-speech/input-text-archive/`, removes empty files.
+3. **prepare-text/prepare_text.py** — YAML-driven text filtering, cleaning, and transformation. Reads `filters.yaml` for per-source rules (text removals, replacements, general cleaning). Writes daily JSON stats to `prepare-text/stats/`.
 
-4. **text-to-speech/text_to_speech.py** — Reads `text-to-speech/text-input/*.txt`, parses metadata headers (`META_FROM`, `META_TITLE`, `META_SOURCE_URL`, `META_SOURCE_KIND`, `META_SOURCE_NAME`), cleans text aggressively, chunks into 3-5k char segments, calls Google Cloud TTS (en-US-Wavenet-F), stitches MP3 chunks with pydub, generates Gemini summary, writes ID3 tags. Output goes to `dropcaster-docker/audio/`.
+4. **process.sh** archives text inputs to `text-to-speech/input-text-archive/`, removes empty files.
+
+5. **text-to-speech/text_to_speech.py** — Reads `text-to-speech/text-input/*.txt`, parses metadata headers (`META_FROM`, `META_TITLE`, `META_SOURCE_URL`, `META_SOURCE_KIND`, `META_SOURCE_NAME`), cleans text aggressively, chunks into 3-5k char segments, calls Google Cloud TTS (en-US-Wavenet-F), stitches MP3 chunks with pydub, generates Gemini summary, writes ID3 tags. Output goes to `dropcaster-docker/audio/`.
 
 5. **Dropcaster** (Docker) regenerates `index.rss` when audio files change. Audio older than 8 weeks is archived.
 
@@ -65,6 +77,9 @@ Root `pyproject.toml` defines shared ruff + basedpyright config. Subproject `pyp
 - **Gemini for summaries**: Model `gemini-3.1-flash-lite-preview`, used in all three subprojects. Client initialized via `GEMINI_API_KEY` env var.
 - **Gotify notifications**: Sent on errors and notable events (unknown email source, NFL whitelist, scraper failures).
 - **Text cleaning happens twice**: once in the intake scripts (URL removal, bracket cleanup) and again in TTS (more aggressive: unsubscribe sections, social links, pronunciation fixes).
+- **Immutability with pyrsistent**: All scripts use `PMap`, `PVector`, `freeze()`, `thaw()` from pyrsistent. `freeze()` at ingestion boundaries (YAML/JSON parse), `thaw()` at serialization. Function parameters use abstract types (`Mapping`, `Sequence`); return types use concrete immutables (`PMap`, `PVector`, `tuple`). Mutable escape hatches are documented with comments where third-party APIs require mutation (e.g., mutagen ID3 tags, pydub audio).
+- **`Final` annotations**: Used on all single-assignment local variables (not inside loops — Python limitation).
+- **Frozen dataclasses**: `@dataclass(frozen=True, slots=True)` for all dataclasses.
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ I created this in order to consume Substack subscriptions in the form of a podca
 - `process.sh` orchestrates the pipeline every 20 minutes:
   - IMAP parsing (`imap/parse_email.py`) downloads unseen emails and writes text inputs with metadata headers.
   - RSS parsing (`rss/check-rss.py`) reads `rss/feeds.txt`, fetches new items, and writes text inputs with metadata headers.
+  - Text preparation (`prepare-text/prepare_text.py`) applies YAML-driven per-source filtering, cleaning, and transformation. Writes daily JSON stats.
   - Archives a copy of text inputs to `text-to-speech/input-text-archive`.
   - Google TTS (`text-to-speech/text_to_speech.py`) chunks text, generates MP3s, writes ID3 tags, and moves audio into `dropcaster-docker/audio`.
   - Dropcaster renders the RSS feed when audio changes.
@@ -18,11 +19,25 @@ I created this in order to consume Substack subscriptions in the form of a podca
 Optional scripts:
 - None (OpenAI/AWS TTS scripts removed).
 
+## Development
+
+Each subproject is an independent uv-managed Python project. From any subproject directory:
+
+```bash
+uv sync                      # Install deps
+uv run pytest -v             # Run tests
+uv run ruff check .          # Lint
+uv run ruff format --check . # Format check
+uv run basedpyright          # Type check
+```
+
+CI (GitHub Actions) runs all four checks on every PR and push to main across all subprojects.
+
 ## Runtime requirements
 
 - Ubuntu + cron (current schedule: `*/20 * * * * bash -l /home/flog99/dev/podcast-transcribe/process-caller.sh >> /home/flog99/process-log.log 2>&1`)
 - Docker + Docker Compose (Dropcaster and nginx-proxy stack).
-- Python via `pyenv` + `uv` for IMAP/RSS/Google TTS (pyproject requires >=3.9).
+- Python 3.12+ via `pyenv` + `uv` for all subprojects.
 - Playwright browsers installed for IMAP/RSS fetches.
 - `ffmpeg` available on PATH (required by `pydub`).
 - Dropcaster is a git submodule (`dropcaster-docker/dropcaster`), so run `git submodule update --init --recursive` after cloning.
@@ -139,6 +154,7 @@ nginx-proxy + ACME:
 
 ## Manual runs
 
-- IMAP parser: `cd imap && /home/flog99/.local/bin/uv run python3 parse_email.py`
-- RSS parser: `cd rss && /home/flog99/.local/bin/uv run python3 check-rss.py`
-- Google TTS: `cd text-to-speech && /home/flog99/.local/bin/uv run python3 text_to_speech.py`
+- IMAP parser: `cd imap && uv run python3 parse_email.py`
+- RSS parser: `cd rss && uv run python3 check-rss.py`
+- Prepare text: `cd prepare-text && uv run python3 prepare_text.py`
+- Google TTS: `cd text-to-speech && uv run python3 text_to_speech.py`

--- a/imap/parse_email.py
+++ b/imap/parse_email.py
@@ -2,111 +2,118 @@ import logging
 import os
 import pathlib
 import re
+from collections.abc import Mapping, Sequence
+from typing import Final
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import requests
 import yt_dlp
 from bs4 import BeautifulSoup
+from google import genai
 from imap_tools.consts import MailMessageFlags
 from imap_tools.mailbox import MailBox
 from imap_tools.query import AND
-from mutagen.id3 import ID3
-from mutagen.id3._frames import TIT2, TT3, WXXX
-from mutagen.id3._util import ID3NoHeaderError
-from google import genai
+from mutagen.id3 import ID3, TIT2, TIT3, WXXX, ID3NoHeaderError  # pyright: ignore[reportPrivateImportUsage]
 from playwright.sync_api import sync_playwright
+from pyrsistent import PMap, PVector, pmap, pvector
 from requests.adapters import HTTPAdapter
 from trafilatura import bare_extraction, extract
+from trafilatura.settings import Document
 from urllib3.util.retry import Retry
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-output_folder = "../prepare-text/text-input-raw"
-gmail_user = os.getenv("GMAIL_PODCAST_ACCOUNT")
-gmail_password = os.getenv("GMAIL_PODCAST_ACCOUNT_APP_PASSWORD")
-local_scraper_url = "http://localhost:3001/fetch"
-summary_model = "gemini-3.1-flash-lite-preview"
-_gemini_client = None
+output_folder: Final = "../prepare-text/text-input-raw"
+gmail_user: Final = os.getenv("GMAIL_PODCAST_ACCOUNT")
+gmail_password: Final = os.getenv("GMAIL_PODCAST_ACCOUNT_APP_PASSWORD")
+local_scraper_url: Final = "http://localhost:3001/fetch"
+summary_model: Final = "gemini-3.1-flash-lite-preview"
+_gemini_client: genai.Client | None = None
 
-# Create a Retry object with zero retries
-retry_strategy = Retry(
-    total=0,  # Total number of retries to allow
-    connect=0,  # Number of connection-related retries to allow
-    read=0,  # Number of read-related retries to allow
-    redirect=0,  # Number of redirection-related retries to allow
-    status=0,  # Number of retries to allow based on HTTP response status codes
+retry_strategy: Final = Retry(
+    total=0,
+    connect=0,
+    read=0,
+    redirect=0,
+    status=0,
 )
 
-# Create an HTTPAdapter with your retry strategy
-adapter = HTTPAdapter(max_retries=retry_strategy)
+adapter: Final = HTTPAdapter(max_retries=retry_strategy)
 
 
-def send_gotify_notification(title, message, priority=6) -> None:
-    gotify_server = os.environ.get("GOTIFY_SERVER")
-    gotify_token = os.environ.get("GOTIFY_TOKEN")
+def send_gotify_notification(title: str, message: str, priority: int = 6) -> None:
+    gotify_server: Final = os.environ.get("GOTIFY_SERVER")
+    gotify_token: Final = os.environ.get("GOTIFY_TOKEN")
     if not gotify_server or not gotify_token:
         logging.warning("Gotify env vars not set; skipping notification.")
         return
     logging.info("Sending Gotify notification")
-    gotify_url = f"{gotify_server}/message?token={gotify_token}"
-    data = {"title": title, "message": message, "priority": priority}
-    requests.post(gotify_url, data=data)
+    gotify_url: Final = f"{gotify_server}/message?token={gotify_token}"
+    # Mutable: requests requires dict
+    data: Final[dict[str, str | int]] = {"title": title, "message": message, "priority": priority}
+    _ = requests.post(gotify_url, data=data, timeout=30)
 
 
-def normalize_text(value):
+def normalize_text(value: str) -> str:
     return " ".join(value.strip().lower().split())
 
 
-def unfold_header_value(value):
+def unfold_header_value(value: str | None) -> str:
     if not value:
         return ""
-    unfolded = re.sub(r"\r?\n[ \t]+", " ", value)
-    unfolded = re.sub(r"[\r\n]+", " ", unfolded)
-    return unfolded.strip()
+    unfolded: Final = re.sub(r"\r?\n[ \t]+", " ", value)
+    unfolded2: Final = re.sub(r"[\r\n]+", " ", unfolded)
+    return unfolded2.strip()
 
 
-def clean_substack_url(url):
+def clean_substack_url(url: str) -> str:
     try:
-        parsed = urlparse(url)
+        parsed: Final = urlparse(url)
         if "substack.com" not in parsed.netloc or not parsed.query:
             return url
-        params = parse_qs(parsed.query)
-        publication_id = params.get("publication_id", [None])[0]
-        post_id = params.get("post_id", [None])[0]
+        params: Final = parse_qs(parsed.query)
+        publication_id: Final = params.get("publication_id", [None])[0]
+        post_id: Final = params.get("post_id", [None])[0]
         if not publication_id or not post_id:
             return url
-        query = urlencode({"publication_id": publication_id, "post_id": post_id})
+        query: Final = urlencode({"publication_id": publication_id, "post_id": post_id})
         return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", query, ""))
-    except Exception:
+    except Exception:  # noqa: BLE001
         return url
 
 
-def extract_links_from_email(msg):
-    links = []
-    if msg.html:
+def extract_links_from_email(msg: object) -> PVector[PMap[str, str]]:
+    html_body: Final = getattr(msg, "html", None)
+    text_body: Final = getattr(msg, "text", None)
+    raw_links: list[PMap[str, str]] = []  # Mutable: accumulation before dedup
+    if html_body:
         logging.info("Parsing HTML to extract links")
-        soup = BeautifulSoup(msg.html, "html.parser")
-        for anchor in soup.find_all("a", href=True):
-            text = anchor.get_text(" ", strip=True)
-            links.append({"href": anchor["href"], "text": text})
-    if msg.text:
+        soup: Final = BeautifulSoup(html_body, "html.parser")  # pyright: ignore[reportAny]
+        for anchor in soup.find_all("a", href=True):  # pyright: ignore[reportAny]
+            text = anchor.get_text(" ", strip=True)  # pyright: ignore[reportAny]
+            raw_links.append(pmap({"href": str(anchor["href"]), "text": str(text)}))  # pyright: ignore[reportAny]
+    if text_body:
         logging.info("Parsing plain text to extract links")
-        links.extend(
-            {"href": url, "text": ""}
-            for url in re.findall(r"https?://[^\s)<>\"']+", msg.text)
+        raw_links.extend(
+            pmap({"href": str(url), "text": ""})  # pyright: ignore[reportAny]
+            for url in re.findall(r"https?://[^\s)<>\"']+", text_body)  # pyright: ignore[reportAny]
         )
-    deduped = []
-    seen = set()
+    return _dedup_links(raw_links)
+
+
+def _dedup_links(links: Sequence[PMap[str, str]]) -> PVector[PMap[str, str]]:
+    seen: set[str] = set()  # Mutable: tracking seen hrefs during dedup
+    deduped: list[PMap[str, str]] = []  # Mutable: accumulation before freeze
     for link in links:
         href = link["href"]
         if href not in seen:
             seen.add(href)
             deduped.append(link)
-    return deduped
+    return pvector(deduped)
 
 
-def find_source_url(links, source_kind, subject):
-    subject_norm = normalize_text(subject)
+def find_source_url(links: Sequence[Mapping[str, str]], source_kind: str, subject: str) -> str:  # noqa: PLR0911
+    subject_norm: Final = normalize_text(subject)
     logging.info("Selecting source URL for %s email", source_kind)
     if source_kind == "beehiiv":
         for link in links:
@@ -115,17 +122,11 @@ def find_source_url(links, source_kind, subject):
                 return link["href"]
     if source_kind == "substack":
         for link in links:
-            if (
-                normalize_text(link["text"]) == subject_norm
-                and "substack.com/app-link/post" in link["href"]
-            ):
+            if normalize_text(link["text"]) == subject_norm and "substack.com/app-link/post" in link["href"]:
                 logging.info("Found Substack post link by title match")
                 return clean_substack_url(link["href"])
         for link in links:
-            if (
-                normalize_text(link["text"]) == subject_norm
-                and "open.substack.com" in link["href"]
-            ):
+            if normalize_text(link["text"]) == subject_norm and "open.substack.com" in link["href"]:
                 logging.info("Found Substack open link by title match")
                 return link["href"]
         for link in links:
@@ -143,65 +144,72 @@ def find_source_url(links, source_kind, subject):
     return ""
 
 
-def get_gemini_client():
-    global _gemini_client
+def get_gemini_client() -> genai.Client:
+    global _gemini_client  # noqa: PLW0603
     if _gemini_client is None:
         _gemini_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
     return _gemini_client
 
 
-def generate_summary(text, title):
+def generate_summary(text: str, title: str) -> str:
     if not text.strip():
         logging.info("Summary skipped: empty content")
         return ""
     logging.info("Generating summary via Gemini")
-    prompt = (
+    prompt: Final = (
         "Summarize the article in 2-3 sentences. Focus on key points and keep it concise.\n\n"
         f"Title: {title}\n\nArticle:\n{text}"
     )
     try:
-        client = get_gemini_client()
-        response = client.models.generate_content(
+        client: Final = get_gemini_client()
+        response: Final = client.models.generate_content(  # pyright: ignore[reportUnknownMemberType]
             model=summary_model,
             contents=prompt,
         )
         logging.info("Summary generated")
-        return response.text.strip()
-    except Exception as exc:
-        logging.exception("Summary generation failed: %s", exc)
+    except Exception:
+        logging.exception("Summary generation failed")
         return ""
+    else:
+        summary_text: Final = response.text
+        return summary_text.strip() if summary_text else ""
 
 
-def apply_id3_tags(mp3_path, title, description, source_url) -> None:
+def apply_id3_tags(mp3_path: str, title: str, description: str, source_url: str) -> None:
     logging.info("Writing ID3 tags to MP3")
     try:
-        tags = ID3(mp3_path)
+        tags = ID3(mp3_path)  # Mutable: mutagen requires mutable ID3
     except ID3NoHeaderError:
-        tags = ID3()
+        tags = ID3()  # Mutable: mutagen requires mutable ID3
     if title:
-        tags.add(TIT2(encoding=3, text=title))
+        tags.add(TIT2(encoding=3, text=title))  # pyright: ignore[reportUnknownMemberType]
     if description:
-        tags.add(TT3(encoding=3, text=description))
+        tags.add(TIT3(encoding=3, text=description))  # pyright: ignore[reportUnknownMemberType]
     if source_url:
-        tags.add(WXXX(encoding=3, desc="Source", url=source_url))
-    tags.save(mp3_path)
+        tags.add(WXXX(encoding=3, desc="Source", url=source_url))  # pyright: ignore[reportUnknownMemberType]
+    tags.save(mp3_path)  # pyright: ignore[reportUnknownMemberType]
 
 
-def fetch_and_process_html(url, final_request=False, headers=None, request_body=None):
+def fetch_and_process_html(
+    url: str,
+    *,
+    final_request: bool = False,
+    request_body: Mapping[str, str] | None = None,
+) -> tuple[Document | None, str | None]:
     """Fetches HTML content from a given URL, processes it, and checks if it contains a specific phrase.
 
     Parameters
     ----------
     - url: The URL to fetch the HTML content from.
     - final_request: Boolean indicating if this is the last attempt to fetch the article.
-    - headers: Optional dictionary of headers to include in the request (GET or POST).
     - request_body: Optional dictionary of data for making a POST request instead of a GET.
 
     Returns
     -------
-    - content_text: The processed HTML content as text, or None if the check fails.
+    - A tuple of (parsed document, content text), or (None, None) if fetching fails.
 
     """
+    _ = final_request
     try:
         logging.info("Fetching %s", url)
 
@@ -216,152 +224,157 @@ def fetch_and_process_html(url, final_request=False, headers=None, request_body=
                         "Making GET request to %s with url query parameter",
                         url,
                     )
-                    page.goto(
+                    _ = page.goto(
                         f"{url}?url={request_body['url']}",
                         wait_until="networkidle",
                         timeout=180000,
                     )
                 else:
                     logging.info("Making GET request to %s", url)
-                    page.goto(url, wait_until="networkidle", timeout=180000)
+                    _ = page.goto(url, wait_until="networkidle", timeout=180000)
 
-                # Get rendered HTML content
-                html_content = page.content()
+                html_content: str | None = page.content()
 
-            except Exception as e:
-                logging.exception("Error occurred while fetching %s: %s", url, e)
+            except Exception:
+                logging.exception("Error occurred while fetching %s", url)
                 html_content = None
 
             finally:
                 browser.close()
 
-        html_content_parsed_for_title = bare_extraction(
+        html_content_parsed_for_title: Final = bare_extraction(
             html_content,
             with_metadata=True,
         )
-        webpage_text = extract(html_content, include_comments=False, favor_recall=True)
-        content_text = (
-            (html_content_parsed_for_title.as_dict().get("title") or "")
-            + ".\n"
-            + "\n"
-            + (webpage_text or "")
-        )
+        webpage_text: Final = extract(html_content, include_comments=False, favor_recall=True)
 
+    except Exception:
+        logging.exception("Error occurred")
+        return None, None
+    else:
+        if html_content_parsed_for_title is None:
+            return None, None
+        if not isinstance(html_content_parsed_for_title, Document):
+            return None, None
+        parsed_title: Final = html_content_parsed_for_title.as_dict().get("title") or ""
+        content_text: Final = parsed_title + ".\n" + "\n" + (webpage_text or "")
         return html_content_parsed_for_title, content_text
 
-    except Exception as e:
-        logging.exception("Error occurred: %s", e)
-        return None, None
 
-
-# get list of email subjects from INBOX folder
-with MailBox("imap.gmail.com").login(gmail_user, gmail_password) as mailbox:
-    msgs = mailbox.fetch(AND(seen=False), mark_seen=False)
-    for msg in msgs:
-        subject_raw = unfold_header_value(msg.subject).replace("Fwd: ", "")
-        date_stamp = msg.date.strftime("%Y%m%d-%H%M%S-%f")[0:15]
-        from_name_raw = unfold_header_value(msg.from_values.name)
-        from_email = msg.from_values.email or ""
-        from_name_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", from_name_raw)
-        from_prefix_for_filename = (
-            from_name_for_filename + "- " if from_name_for_filename != "" else ""
-        )
-        subject_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", subject_raw)
-        subject_for_filter_lower = subject_for_filename.lower()
-        if subject_for_filter_lower not in {"link", "youtube"}:
-            output_filename = f"{output_folder}/{date_stamp}-{from_prefix_for_filename}{subject_for_filename}.txt"
-            logging.info("parsing email: %s", output_filename)
-            email_text_raw = msg.text
-            has_beehiiv = bool(msg.headers.get("x-beehiiv-ids"))
-            source_kind = "beehiiv" if has_beehiiv else "substack"
-            all_links = extract_links_from_email(msg)
-            source_url = find_source_url(all_links, source_kind, subject_raw)
-            if not source_url:
-                source_kind = "unknown"
-                send_gotify_notification(
-                    "Unknown email source",
-                    f"No source link found for {from_email} ({subject_raw}).",
-                )
-            output_file = pathlib.Path(output_filename).open("w", encoding="utf-8")
-            metadata_block = "\n".join(
-                [
-                    f"META_FROM: {from_name_raw}",
-                    f"META_TITLE: {subject_raw}",
-                    f"META_SOURCE_URL: {source_url}",
-                    f"META_SOURCE_KIND: {source_kind}",
-                    f"META_SOURCE_NAME: {from_name_raw}",
-                    "META_INTAKE_TYPE: email",
-                ],
-            )
-            logging.info("Writing raw metadata and text to text input")
-            output_file.write(metadata_block + "\n\n" + email_text_raw)
-            output_file.close()
-        elif subject_for_filter_lower == "youtube":
-            email_text_raw = msg.text
-            youtube_url = re.sub(r"[^\S]+", "", email_text_raw)
-            logging.info("fetching youtube audio: %s", youtube_url)
-            ydl_opts = {
-                "format": "bestaudio[protocol!=m3u8][protocol!=m3u8_native]/bestaudio/best",
-                "extractor_args": {"youtube": {"player_client": ["android"]}},
-                "fragment_retries": 10,
-                "retries": 5,
-                "postprocessors": [
-                    {
-                        "key": "FFmpegExtractAudio",
-                        "preferredcodec": "mp3",
-                        "preferredquality": "192",
-                    },
-                ],
-                "outtmpl": "../dropcaster-docker/audio/%(uploader)s- %(title)s.%(ext)s",
-            }
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                info = ydl.extract_info(youtube_url, download=True)
-                base_filename = ydl.prepare_filename(info)
-                mp3_filename = os.path.splitext(base_filename)[0] + ".mp3"
-                video_title = info.get("title") or "YouTube Video"
-                video_url = info.get("webpage_url") or youtube_url
-                video_description = info.get("description") or ""
-                summary = generate_summary(video_description, video_title)
-                description_body = summary or "Summary unavailable."
-                description = f'{video_title}<br/><br/>{description_body}<br/><br/>Source: <a href="{video_url}">{video_url}</a>'
-                if pathlib.Path(mp3_filename).exists():
-                    apply_id3_tags(mp3_filename, video_title, description, video_url)
-                else:
-                    logging.error("Expected MP3 not found: %s", mp3_filename)
-        else:
-            email_text_raw = msg.text
-            url_text_compact = re.sub(r"[^\S]+", "", email_text_raw)
-            logging.info("fetching webpage: %s", url_text_compact)
-            original_url = url_text_compact
-            html_content_parsed_for_title, webpage_text = fetch_and_process_html(
-                url=local_scraper_url,
-                headers={"Content-Type": "application/json"},
-                request_body={"url": original_url},
-            )
-            if webpage_text is None:
-                logging.info(
-                    "could not parse webpage, saving for next time: %s",
-                    original_url,
-                )
+def main() -> None:
+    with MailBox("imap.gmail.com").login(gmail_user, gmail_password) as mailbox:  # pyright: ignore[reportArgumentType]
+        msgs = mailbox.fetch(AND(seen=False), mark_seen=False)  # pyright: ignore[reportUnknownMemberType]
+        for msg in msgs:  # Mutable: imap_tools iterator
+            subject_raw = unfold_header_value(msg.subject).replace("Fwd: ", "")
+            date_stamp = msg.date.strftime("%Y%m%d-%H%M%S-%f")[0:15]
+            from_values = msg.from_values
+            if from_values is None:
+                logging.warning("Skipping message with no from_values")
                 continue
-            raw_title = (
-                html_content_parsed_for_title.as_dict().get("title")
-                or "No title available"
-            )
-            title_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", raw_title)
-            output_filename = f"{output_folder}/{date_stamp}-{title_for_filename}.txt"
-            output_file = pathlib.Path(output_filename).open("w", encoding="utf-8")
-            metadata_block = "\n".join(
-                [
-                    f"META_FROM: {from_name_raw}",
-                    f"META_TITLE: {raw_title}",
-                    f"META_SOURCE_URL: {original_url}",
-                    "META_SOURCE_KIND: url",
-                    "META_INTAKE_TYPE: link",
-                ],
-            )
-            logging.info("Writing metadata block to text input")
-            output_file.write(metadata_block + "\n\n" + webpage_text)
-            output_file.close()
-        flags = MailMessageFlags.SEEN
-        mailbox.flag(msg.uid, flags, True)
+            from_name_raw = unfold_header_value(from_values.name)
+            from_email = from_values.email or ""
+            from_name_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", from_name_raw)
+            from_prefix_for_filename = from_name_for_filename + "- " if from_name_for_filename else ""
+            subject_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", subject_raw)
+            subject_for_filter_lower = subject_for_filename.lower()
+            if subject_for_filter_lower not in {"link", "youtube"}:
+                output_filename = f"{output_folder}/{date_stamp}-{from_prefix_for_filename}{subject_for_filename}.txt"
+                logging.info("parsing email: %s", output_filename)
+                email_text_raw = msg.text
+                has_beehiiv = bool(msg.headers.get("x-beehiiv-ids"))
+                source_kind = "beehiiv" if has_beehiiv else "substack"
+                all_links = extract_links_from_email(msg)
+                source_url = find_source_url(all_links, source_kind, subject_raw)
+                if not source_url:
+                    source_kind = "unknown"
+                    send_gotify_notification(
+                        "Unknown email source",
+                        f"No source link found for {from_email} ({subject_raw}).",
+                    )
+                metadata_block = "\n".join(
+                    (
+                        f"META_FROM: {from_name_raw}",
+                        f"META_TITLE: {subject_raw}",
+                        f"META_SOURCE_URL: {source_url}",
+                        f"META_SOURCE_KIND: {source_kind}",
+                        f"META_SOURCE_NAME: {from_name_raw}",
+                        "META_INTAKE_TYPE: email",
+                    ),
+                )
+                logging.info("Writing raw metadata and text to text input")
+                _ = pathlib.Path(output_filename).write_text(metadata_block + "\n\n" + email_text_raw, encoding="utf-8")
+            elif subject_for_filter_lower == "youtube":
+                email_text_raw = msg.text
+                youtube_url = re.sub(r"[^\S]+", "", email_text_raw)
+                logging.info("fetching youtube audio: %s", youtube_url)
+                ydl_opts = {  # Mutable: yt_dlp requires dict
+                    "format": "bestaudio[protocol!=m3u8][protocol!=m3u8_native]/bestaudio/best",
+                    "extractor_args": {"youtube": {"player_client": ["android"]}},
+                    "fragment_retries": 10,
+                    "retries": 5,
+                    "postprocessors": [
+                        {
+                            "key": "FFmpegExtractAudio",
+                            "preferredcodec": "mp3",
+                            "preferredquality": "192",
+                        },
+                    ],
+                    "outtmpl": "../dropcaster-docker/audio/%(uploader)s- %(title)s.%(ext)s",
+                }
+                with yt_dlp.YoutubeDL(ydl_opts) as ydl:  # pyright: ignore[reportArgumentType]
+                    info = ydl.extract_info(youtube_url, download=True)
+                    base_filename = ydl.prepare_filename(info)
+                    mp3_filename = str(pathlib.Path(str(base_filename)).with_suffix(".mp3"))
+                    video_title = str(info.get("title") or "YouTube Video")
+                    video_url = str(info.get("webpage_url") or youtube_url)
+                    video_description = str(info.get("description") or "")
+                    summary = generate_summary(video_description, video_title)
+                    description_body = summary or "Summary unavailable."
+                    description = (
+                        f"{video_title}<br/><br/>{description_body}"
+                        f'<br/><br/>Source: <a href="{video_url}">{video_url}</a>'
+                    )
+                    if pathlib.Path(mp3_filename).exists():
+                        apply_id3_tags(mp3_filename, video_title, description, video_url)
+                    else:
+                        logging.error("Expected MP3 not found: %s", mp3_filename)
+            else:
+                email_text_raw = msg.text
+                url_text_compact = re.sub(r"[^\S]+", "", email_text_raw)
+                logging.info("fetching webpage: %s", url_text_compact)
+                original_url = url_text_compact
+                html_content_parsed_for_title, webpage_text = fetch_and_process_html(
+                    url=local_scraper_url,
+                    request_body={"url": original_url},  # Mutable: playwright requires dict
+                )
+                if webpage_text is None:
+                    logging.info(
+                        "could not parse webpage, saving for next time: %s",
+                        original_url,
+                    )
+                    continue
+                if html_content_parsed_for_title is None:
+                    logging.info("could not parse webpage title for: %s", original_url)
+                    continue
+                raw_title = html_content_parsed_for_title.as_dict().get("title") or "No title available"
+                title_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", raw_title)
+                output_filename = f"{output_folder}/{date_stamp}-{title_for_filename}.txt"
+                metadata_block = "\n".join(
+                    (
+                        f"META_FROM: {from_name_raw}",
+                        f"META_TITLE: {raw_title}",
+                        f"META_SOURCE_URL: {original_url}",
+                        "META_SOURCE_KIND: url",
+                        "META_INTAKE_TYPE: link",
+                    ),
+                )
+                logging.info("Writing metadata block to text input")
+                _ = pathlib.Path(output_filename).write_text(metadata_block + "\n\n" + webpage_text, encoding="utf-8")
+            msg_uid = msg.uid
+            if msg_uid is not None:
+                flags = MailMessageFlags.SEEN
+                _ = mailbox.flag(msg_uid, flags, True)  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+
+
+if __name__ == "__main__":
+    main()

--- a/imap/pyproject.toml
+++ b/imap/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "markdown>=3.7",
     "mutagen>=1.47.0",
     "google-genai>=1.0.0",
+    "pyrsistent>=0.20.0",
     "playwright>=1.49.1",
     "requests>=2.32.3",
     "trafilatura>=2.0.0",
@@ -20,6 +21,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "basedpyright>=1.20.0",
+    "pytest>=8.0",
     "ruff>=0.7.0",
     "types-beautifulsoup4>=4.12.0",
     "types-python-dateutil>=2.9.0",

--- a/imap/test_parse_email.py
+++ b/imap/test_parse_email.py
@@ -1,0 +1,278 @@
+# pyright: reportExplicitAny=false, reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+# pyright: reportUnannotatedClassAttribute=false
+from pyrsistent import PMap, PVector, pmap, pvector
+
+from parse_email import (
+    _dedup_links,
+    clean_substack_url,
+    extract_links_from_email,
+    find_source_url,
+    normalize_text,
+    unfold_header_value,
+)
+
+
+class TestNormalizeText:
+    def test_basic_normalization(self):
+        assert normalize_text("  Hello   World  ") == "hello world"
+
+    def test_tabs_and_newlines(self):
+        assert normalize_text("Hello\t\n  World") == "hello world"
+
+    def test_already_normalized(self):
+        assert normalize_text("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert not normalize_text("")
+
+    def test_single_word(self):
+        assert normalize_text("  HELLO  ") == "hello"
+
+    def test_mixed_case_with_extra_spaces(self):
+        assert normalize_text("  Read   Online  ") == "read online"
+
+
+class TestUnfoldHeaderValue:
+    def test_none_input(self):
+        assert not unfold_header_value(None)
+
+    def test_empty_string(self):
+        assert not unfold_header_value("")
+
+    def test_no_folding(self):
+        assert unfold_header_value("Simple Header") == "Simple Header"
+
+    def test_crlf_space_folding(self):
+        assert unfold_header_value("Hello\r\n World") == "Hello World"
+
+    def test_lf_tab_folding(self):
+        assert unfold_header_value("Hello\n\tWorld") == "Hello World"
+
+    def test_multiple_folds(self):
+        assert unfold_header_value("A\r\n B\r\n C") == "A B C"
+
+    def test_bare_newlines_removed(self):
+        assert unfold_header_value("Line1\nLine2\nLine3") == "Line1 Line2 Line3"
+
+    def test_strips_surrounding_whitespace(self):
+        assert unfold_header_value("  spaced  ") == "spaced"
+
+    def test_crlf_without_continuation(self):
+        assert unfold_header_value("End\r\nStart") == "End Start"
+
+
+class TestCleanSubstackUrl:
+    def test_non_substack_url_unchanged(self):
+        url = "https://example.com/article?foo=bar"
+        assert clean_substack_url(url) == url
+
+    def test_substack_url_no_query(self):
+        url = "https://newsletter.substack.com/p/my-post"
+        assert clean_substack_url(url) == url
+
+    def test_strips_tracking_params(self):
+        url = (
+            "https://newsletter.substack.com/api/v1/redirect?"
+            "publication_id=123&post_id=456&utm_source=email&utm_medium=link&tracking=xyz"
+        )
+        result = clean_substack_url(url)
+        assert "publication_id=123" in result
+        assert "post_id=456" in result
+        assert "utm_source" not in result
+        assert "tracking" not in result
+
+    def test_missing_publication_id_returns_original(self):
+        url = "https://newsletter.substack.com/api/v1/redirect?post_id=456&utm_source=email"
+        assert clean_substack_url(url) == url
+
+    def test_missing_post_id_returns_original(self):
+        url = "https://newsletter.substack.com/api/v1/redirect?publication_id=123&utm_source=email"
+        assert clean_substack_url(url) == url
+
+    def test_preserves_scheme_and_netloc(self):
+        url = "https://newsletter.substack.com/api/v1/redirect?publication_id=111&post_id=222&extra=junk"
+        result = clean_substack_url(url)
+        assert result.startswith("https://newsletter.substack.com/")
+
+
+class TestFindSourceUrl:
+    def test_beehiiv_read_online(self):
+        links = pvector(
+            [
+                pmap({"href": "https://example.com/other", "text": "Other link"}),
+                pmap({"href": "https://beehiiv.com/article", "text": "Read Online"}),
+            ]
+        )
+        result = find_source_url(links, "beehiiv", "My Newsletter")
+        assert result == "https://beehiiv.com/article"
+
+    def test_beehiiv_case_insensitive(self):
+        links = pvector(
+            [
+                pmap({"href": "https://beehiiv.com/article", "text": "  READ   ONLINE  "}),
+            ]
+        )
+        result = find_source_url(links, "beehiiv", "Newsletter")
+        assert result == "https://beehiiv.com/article"
+
+    def test_beehiiv_no_read_online(self):
+        links = pvector(
+            [
+                pmap({"href": "https://beehiiv.com/article", "text": "Click here"}),
+            ]
+        )
+        result = find_source_url(links, "beehiiv", "Newsletter")
+        assert not result
+
+    def test_substack_app_link_by_title(self):
+        links = pvector(
+            [
+                pmap({"href": "https://substack.com/app-link/post?pub=1&post=2", "text": "My Post Title"}),
+            ]
+        )
+        result = find_source_url(links, "substack", "My Post Title")
+        assert "substack.com" in result
+
+    def test_substack_open_link_by_title(self):
+        links = pvector(
+            [
+                pmap({"href": "https://open.substack.com/pub/author/p/my-post", "text": "My Post"}),
+            ]
+        )
+        result = find_source_url(links, "substack", "My Post")
+        assert result == "https://open.substack.com/pub/author/p/my-post"
+
+    def test_substack_app_link_fallback_no_title_match(self):
+        links = pvector(
+            [
+                pmap({"href": "https://substack.com/app-link/post?pub=1&post=2", "text": "Different Text"}),
+            ]
+        )
+        result = find_source_url(links, "substack", "My Post Title")
+        assert "substack.com/app-link/post" in result
+
+    def test_substack_open_link_fallback_no_title_match(self):
+        links = pvector(
+            [
+                pmap({"href": "https://open.substack.com/pub/author/p/my-post", "text": "Something Else"}),
+            ]
+        )
+        result = find_source_url(links, "substack", "My Post Title")
+        assert "open.substack.com" in result
+
+    def test_substack_generic_fallback(self):
+        links = pvector(
+            [
+                pmap({"href": "https://newsletter.substack.com/p/my-article?pub=1&post=2", "text": "Read more"}),
+            ]
+        )
+        result = find_source_url(links, "substack", "Totally Different")
+        assert "substack.com" in result
+
+    def test_unknown_source_kind(self):
+        links = pvector(
+            [
+                pmap({"href": "https://example.com", "text": "Link"}),
+            ]
+        )
+        result = find_source_url(links, "unknown", "Subject")
+        assert not result
+
+    def test_empty_links(self):
+        empty: PVector[PMap[str, str]] = pvector()
+        result = find_source_url(empty, "substack", "Subject")
+        assert not result
+
+    def test_accepts_plain_dicts(self):
+        """find_source_url accepts Sequence[Mapping] so plain dicts work too."""
+        links = [
+            {"href": "https://beehiiv.com/article", "text": "Read Online"},
+        ]
+        result = find_source_url(links, "beehiiv", "Newsletter")
+        assert result == "https://beehiiv.com/article"
+
+
+class TestDedupLinks:
+    def test_removes_duplicates(self):
+        links = [
+            pmap({"href": "https://a.com", "text": "A"}),
+            pmap({"href": "https://b.com", "text": "B"}),
+            pmap({"href": "https://a.com", "text": "A duplicate"}),
+        ]
+        result = _dedup_links(links)
+        assert len(result) == 2
+        assert result[0]["href"] == "https://a.com"
+        assert result[1]["href"] == "https://b.com"
+
+    def test_preserves_first_occurrence(self):
+        links = [
+            pmap({"href": "https://a.com", "text": "First"}),
+            pmap({"href": "https://a.com", "text": "Second"}),
+        ]
+        result = _dedup_links(links)
+        assert len(result) == 1
+        assert result[0]["text"] == "First"
+
+    def test_empty_input(self):
+        result = _dedup_links([])
+        assert len(result) == 0
+
+    def test_returns_pvector(self):
+        links = [pmap({"href": "https://a.com", "text": "A"})]
+        result = _dedup_links(links)
+        assert isinstance(result, PVector)
+
+
+class TestExtractLinksFromEmail:
+    def test_extracts_html_links(self):
+        class FakeMsg:
+            html: str | None = '<html><body><a href="https://example.com">Example</a></body></html>'
+            text: str | None = None
+
+        result = extract_links_from_email(FakeMsg())
+        assert len(result) == 1
+        assert result[0]["href"] == "https://example.com"
+        assert result[0]["text"] == "Example"
+
+    def test_extracts_text_links(self):
+        class FakeMsg:
+            html: str | None = None
+            text: str | None = "Check out https://example.com and https://other.com for more."
+
+        result = extract_links_from_email(FakeMsg())
+        assert len(result) == 2
+        assert result[0]["href"] == "https://example.com"
+        assert result[1]["href"] == "https://other.com"
+
+    def test_deduplicates_across_html_and_text(self):
+        class FakeMsg:
+            html: str | None = '<html><body><a href="https://example.com">Link</a></body></html>'
+            text: str | None = "Visit https://example.com for more."
+
+        result = extract_links_from_email(FakeMsg())
+        assert len(result) == 1
+
+    def test_no_links(self):
+        class FakeMsg:
+            html: str | None = "<html><body>No links here</body></html>"
+            text: str | None = "Also no links"
+
+        result = extract_links_from_email(FakeMsg())
+        assert len(result) == 0
+
+    def test_none_html_and_text(self):
+        class FakeMsg:
+            html: str | None = None
+            text: str | None = None
+
+        result = extract_links_from_email(FakeMsg())
+        assert len(result) == 0
+
+    def test_returns_pvector_of_pmaps(self):
+        class FakeMsg:
+            html: str | None = '<html><body><a href="https://example.com">Ex</a></body></html>'
+            text: str | None = None
+
+        result = extract_links_from_email(FakeMsg())
+        assert isinstance(result, PVector)
+        assert isinstance(result[0], PMap)

--- a/imap/uv.lock
+++ b/imap/uv.lock
@@ -415,6 +415,7 @@ dependencies = [
     { name = "markdown" },
     { name = "mutagen" },
     { name = "playwright" },
+    { name = "pyrsistent" },
     { name = "requests" },
     { name = "trafilatura" },
     { name = "waybackpy" },
@@ -424,6 +425,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "types-beautifulsoup4" },
     { name = "types-python-dateutil" },
@@ -438,6 +440,7 @@ requires-dist = [
     { name = "markdown", specifier = ">=3.7" },
     { name = "mutagen", specifier = ">=1.47.0" },
     { name = "playwright", specifier = ">=1.49.1" },
+    { name = "pyrsistent", specifier = ">=0.20.0" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "waybackpy", specifier = ">=3.0.6" },
@@ -447,6 +450,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.20.0" },
+    { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.7.0" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0" },
     { name = "types-python-dateutil", specifier = ">=2.9.0" },
@@ -460,6 +464,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/59/2644cd451bf2f88633c946c4ad881397ce7c4ef41328ac90c568919ae183/imap_tools-1.9.0.tar.gz", hash = "sha256:516a3477f16dedea91ac2316dc6f891f27f144266af6134c203ec852a27719f7", size = 45146 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/a4/6c53c5435799fa1f40c1bea80e5bf0f3162dc971d7044634e8ffd8fc059f/imap_tools-1.9.0-py3-none-any.whl", hash = "sha256:a3171e048ea8d85920822134191b5d91f0890668fe3ca1e1e6043fd2ec03c1e7", size = 34077 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
 ]
 
 [[package]]
@@ -569,6 +582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366 },
+]
+
+[[package]]
 name = "playwright"
 version = "1.49.1"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +606,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/52/95efac704bf36b770a2522d88a6dee298042845d10bfb35f7ca0fcc36d91/playwright-1.49.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd9bc8dab37aa25198a01f555f0a2e2c3813fe200fef018ac34dfe86b34994b9", size = 43744353 },
     { url = "https://files.pythonhosted.org/packages/f9/97/a3fccc9aaa6da83890772e9980703b0ea6b1e1ad42042fb50df3aef6c641/playwright-1.49.1-py3-none-win32.whl", hash = "sha256:43b304be67f096058e587dac453ece550eff87b8fbed28de30f4f022cc1745bb", size = 34060663 },
     { url = "https://files.pythonhosted.org/packages/71/a9/bd88ac0bd498c91aab3aba2e393d1fa59f72a7243e9265ccbf4861ca4f64/playwright-1.49.1-py3-none-win_amd64.whl", hash = "sha256:47b23cb346283278f5b4d1e1990bcb6d6302f80c0aa0ca93dd0601a1400191df", size = 34060667 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
 ]
 
 [[package]]
@@ -683,6 +714,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/a7/8faaa62a488a2a1e0d56969757f087cbd2729e9bcfa508c230299f366b4c/pyee-12.0.0.tar.gz", hash = "sha256:c480603f4aa2927d4766eb41fa82793fe60a82cbfdb8d688e0d08c55a534e145", size = 29675 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/0d/95993c08c721ec68892547f2117e8f9dfbcef2ca71e098533541b4a54d5f/pyee-12.0.0-py3-none-any.whl", hash = "sha256:7b14b74320600049ccc7d0e0b1becd3b4bd0a03c745758225e31a59f4095c990", size = 14831 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "pyrsistent"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/3a/5031723c09068e9c8c2f0bc25c3a9245f2b1d1aea8396c787a408f2b95ca/pyrsistent-0.20.0.tar.gz", hash = "sha256:4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4", size = 103642 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/ee/ff2ed52032ac1ce2e7ba19e79bd5b05d152ebfb77956cf08fcd6e8d760ea/pyrsistent-0.20.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:09848306523a3aba463c4b49493a760e7a6ca52e4826aa100ee99d8d39b7ad1e", size = 83537 },
+    { url = "https://files.pythonhosted.org/packages/80/f1/338d0050b24c3132bcfc79b68c3a5f54bce3d213ecef74d37e988b971d8a/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a14798c3005ec892bbada26485c2eea3b54109cb2533713e355c806891f63c5e", size = 122615 },
+    { url = "https://files.pythonhosted.org/packages/07/3a/e56d6431b713518094fae6ff833a04a6f49ad0fbe25fb7c0dc7408e19d20/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b14decb628fac50db5e02ee5a35a9c0772d20277824cfe845c8a8b717c15daa3", size = 122335 },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/5f40a4d5e985a43b43f607250e766cdec28904682c3505eb0bd343a4b7db/pyrsistent-0.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e2c116cc804d9b09ce9814d17df5edf1df0c624aba3b43bc1ad90411487036d", size = 118510 },
+    { url = "https://files.pythonhosted.org/packages/1c/13/e6a22f40f5800af116c02c28e29f15c06aa41cb2036f6a64ab124647f28b/pyrsistent-0.20.0-cp312-cp312-win32.whl", hash = "sha256:e78d0c7c1e99a4a45c99143900ea0546025e41bb59ebc10182e947cf1ece9174", size = 60865 },
+    { url = "https://files.pythonhosted.org/packages/75/ef/2fa3b55023ec07c22682c957808f9a41836da4cd006b5f55ec76bf0fbfa6/pyrsistent-0.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:4021a7f963d88ccd15b523787d18ed5e5269ce57aa4037146a2377ff607ae87d", size = 63239 },
+    { url = "https://files.pythonhosted.org/packages/23/88/0acd180010aaed4987c85700b7cc17f9505f3edb4e5873e4dc67f613e338/pyrsistent-0.20.0-py3-none-any.whl", hash = "sha256:c55acc4733aad6560a7f5f818466631f07efc001fd023f34a6c203f8b6df0f0b", size = 58106 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
 ]
 
 [[package]]

--- a/prepare-text/prepare_text.py
+++ b/prepare-text/prepare_text.py
@@ -1,3 +1,4 @@
+# pyright: reportExplicitAny=false, reportAny=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false
 """Text preparation pipeline: filtering, cleaning, and transformation.
 
 Reads raw text files from text-input-raw/, applies filters and cleaning rules
@@ -6,20 +7,24 @@ from filters.yaml, and writes cleaned output to text-input-cleaned/ for TTS.
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import os
 import pathlib
 import re
 import shutil
-from datetime import datetime, timedelta
-from typing import Final
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 import markdown
 import requests
 import yaml
 from bs4 import BeautifulSoup
 from google import genai
+from pyrsistent import PMap, PVector, freeze, pmap, pvector, thaw
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
@@ -33,6 +38,10 @@ CONFIG_FILE: Final = "filters.yaml"
 CHARACTER_LIMIT: Final = 150000
 STATS_RETENTION_DAYS: Final = 365
 LLM_MODEL: Final = "gemini-3.1-flash-lite-preview"
+
+type YamlDict = PMap[str, Any]
+type YamlList = PVector[YamlDict]
+type StatsDict = PMap[str, PMap[str, Any]]
 
 _gemini_client: genai.Client | None = None
 
@@ -62,7 +71,7 @@ def send_gotify_notification(title: str, message: str, priority: int = 6) -> Non
         return
     final_url: Final = f"{final_server}/message?token={final_token}"
     final_data: Final = {"title": title, "message": message, "priority": priority}
-    requests.post(final_url, data=final_data, timeout=30)
+    _ = requests.post(final_url, data=final_data, timeout=30)
 
 
 # ---------------------------------------------------------------------------
@@ -70,11 +79,11 @@ def send_gotify_notification(title: str, message: str, priority: int = 6) -> Non
 # ---------------------------------------------------------------------------
 
 
-def split_metadata(raw_text: str) -> tuple[dict[str, str], str]:
+def split_metadata(raw_text: str) -> tuple[PMap[str, str], str]:
     if not raw_text.startswith("META_"):
-        return {}, raw_text
+        return pmap({}), raw_text
     final_lines: Final = raw_text.splitlines()
-    metadata: Final[dict[str, str]] = {}
+    metadata: dict[str, str] = {}
     current_key: str | None = None
     content_start: int = len(final_lines)
     for idx, line in enumerate(final_lines):
@@ -88,19 +97,15 @@ def split_metadata(raw_text: str) -> tuple[dict[str, str], str]:
             metadata[current_key] = value_raw.strip()
             continue
         if line.startswith((" ", "\t")) and current_key:
-            metadata[current_key] = (
-                f"{metadata.get(current_key, '')} {line.strip()}".strip()
-            )
+            metadata[current_key] = f"{metadata.get(current_key, '')} {line.strip()}".strip()
             continue
         if not line.strip():
             content_start = idx + 1
             break
         content_start = idx
         break
-    final_content: Final = (
-        "\n".join(final_lines[content_start:]) if content_start < len(final_lines) else ""
-    )
-    return metadata, final_content
+    final_content: Final = "\n".join(final_lines[content_start:]) if content_start < len(final_lines) else ""
+    return pmap(metadata), final_content
 
 
 # ---------------------------------------------------------------------------
@@ -131,10 +136,10 @@ VALID_CLEANING_KEYS: Final = frozenset(
 )
 
 
-def parse_flags(flags_raw: str | list[str] | None) -> int:
+def parse_flags(flags_raw: str | Sequence[str] | None) -> int:
     if flags_raw is None:
         return 0
-    final_flag_list: Final = [flags_raw] if isinstance(flags_raw, str) else flags_raw
+    final_flag_list: Final = [flags_raw] if isinstance(flags_raw, str) else list(flags_raw)
     result: int = 0
     for flag_name in final_flag_list:
         if flag_name not in VALID_FLAGS:
@@ -149,15 +154,15 @@ def parse_flags(flags_raw: str | list[str] | None) -> int:
     return result
 
 
-def validate_match_block(match_block: dict, context: str) -> None:
-    if not isinstance(match_block, dict) or not match_block:
+def validate_match_block(match_block: Mapping[str, Any], context: str) -> None:
+    if not match_block:
         msg = f"{context}: 'match' must be a non-empty dict"
         raise ValueError(msg)
     for field, operators in match_block.items():
         if field not in VALID_MATCH_FIELDS:
             msg = f"{context}: unknown match field {field!r} (valid: {', '.join(sorted(VALID_MATCH_FIELDS))})"
             raise ValueError(msg)
-        if not isinstance(operators, dict) or not operators:
+        if not isinstance(operators, (dict, PMap)) or not operators:
             msg = f"{context}: match field {field!r} must be a dict with operators"
             raise ValueError(msg)
         for op in operators:
@@ -167,7 +172,7 @@ def validate_match_block(match_block: dict, context: str) -> None:
                 raise ValueError(msg)
 
 
-def validate_config(config: dict) -> None:
+def validate_config(config: Mapping[str, Any]) -> None:
     final_valid_top_keys: Final = frozenset(
         {"filters", "general_cleaning", "text_removals", "text_replacements"},
     )
@@ -177,50 +182,51 @@ def validate_config(config: dict) -> None:
             raise ValueError(msg)
 
     # Validate filters
-    for idx, filt in enumerate(config.get("filters") or []):
-        final_ctx = f"filters[{idx}]"
+    final_filter_list: Final = config.get("filters") or []
+    for idx, filt in enumerate(final_filter_list):
+        ctx = f"filters[{idx}]"
         if "match" not in filt:
-            msg = f"{final_ctx}: 'match' is required"
+            msg = f"{ctx}: 'match' is required"
             raise ValueError(msg)
-        validate_match_block(filt["match"], final_ctx)
+        validate_match_block(filt["match"], ctx)
         if "reason" not in filt:
-            msg = f"{final_ctx}: 'reason' is required"
+            msg = f"{ctx}: 'reason' is required"
             raise ValueError(msg)
-        final_action = filt.get("action", "skip")
-        if final_action not in VALID_ACTIONS:
-            msg = f"{final_ctx}: invalid action {final_action!r} (valid: {', '.join(sorted(VALID_ACTIONS))})"
+        action: str = filt.get("action", "skip")
+        if action not in VALID_ACTIONS:
+            msg = f"{ctx}: invalid action {action!r} (valid: {', '.join(sorted(VALID_ACTIONS))})"
             raise ValueError(msg)
-        if final_action == "notify" and "notify" not in filt:
-            msg = f"{final_ctx}: action 'notify' requires a 'notify' block"
+        if action == "notify" and "notify" not in filt:
+            msg = f"{ctx}: action 'notify' requires a 'notify' block"
             raise ValueError(msg)
         if "notify" in filt:
-            final_notify = filt["notify"]
-            if "priority" not in final_notify:
-                msg = f"{final_ctx}: notify block requires 'priority'"
+            notify_block = filt["notify"]
+            if "priority" not in notify_block:
+                msg = f"{ctx}: notify block requires 'priority'"
                 raise ValueError(msg)
-            if "title" not in final_notify:
-                msg = f"{final_ctx}: notify block requires 'title'"
+            if "title" not in notify_block:
+                msg = f"{ctx}: notify block requires 'title'"
                 raise ValueError(msg)
         if "llm_check" in filt and not isinstance(filt["llm_check"], str):
-            msg = f"{final_ctx}: 'llm_check' must be a string"
+            msg = f"{ctx}: 'llm_check' must be a string"
             raise ValueError(msg)
 
     # Validate general_cleaning
     final_gc: Final = config.get("general_cleaning") or {}
     for key, value in final_gc.items():
         if key == "overrides":
-            if not isinstance(value, list):
+            if not isinstance(value, (list, PVector)):
                 msg = "general_cleaning.overrides must be a list"
                 raise ValueError(msg)
             for oidx, override in enumerate(value):
-                final_octx = f"general_cleaning.overrides[{oidx}]"
+                octx = f"general_cleaning.overrides[{oidx}]"
                 if "match" not in override:
-                    msg = f"{final_octx}: 'match' is required"
+                    msg = f"{octx}: 'match' is required"
                     raise ValueError(msg)
-                validate_match_block(override["match"], final_octx)
+                validate_match_block(override["match"], octx)
                 for okey in override:
                     if okey != "match" and okey not in VALID_CLEANING_KEYS:
-                        msg = f"{final_octx}: unknown key {okey!r}"
+                        msg = f"{octx}: unknown key {okey!r}"
                         raise ValueError(msg)
         elif key not in VALID_CLEANING_KEYS:
             msg = f"general_cleaning: unknown key {key!r}"
@@ -230,79 +236,85 @@ def validate_config(config: dict) -> None:
             raise ValueError(msg)
 
     # Validate text_removals
-    for idx, removal in enumerate(config.get("text_removals") or []):
-        final_rctx = f"text_removals[{idx}]"
+    final_removal_list: Final = config.get("text_removals") or []
+    for idx, removal in enumerate(final_removal_list):
+        rctx = f"text_removals[{idx}]"
         if "pattern" not in removal:
-            msg = f"{final_rctx}: 'pattern' is required"
+            msg = f"{rctx}: 'pattern' is required"
             raise ValueError(msg)
         if "reason" not in removal:
-            msg = f"{final_rctx}: 'reason' is required"
+            msg = f"{rctx}: 'reason' is required"
             raise ValueError(msg)
-        final_rflags = parse_flags(removal.get("flags"))
+        rflags = parse_flags(removal.get("flags"))
         try:
-            re.compile(removal["pattern"], final_rflags)
+            _ = re.compile(removal["pattern"], rflags)
         except re.error as exc:
-            msg = f"{final_rctx}: invalid regex: {exc}"
+            msg = f"{rctx}: invalid regex: {exc}"
             raise ValueError(msg) from exc
 
     # Validate text_replacements
-    for idx, repl in enumerate(config.get("text_replacements") or []):
-        final_pctx = f"text_replacements[{idx}]"
+    final_repl_list: Final = config.get("text_replacements") or []
+    for idx, repl in enumerate(final_repl_list):
+        pctx = f"text_replacements[{idx}]"
         if "pattern" not in repl:
-            msg = f"{final_pctx}: 'pattern' is required"
+            msg = f"{pctx}: 'pattern' is required"
             raise ValueError(msg)
         if "replacement" not in repl:
-            msg = f"{final_pctx}: 'replacement' is required"
+            msg = f"{pctx}: 'replacement' is required"
             raise ValueError(msg)
         if "reason" not in repl:
-            msg = f"{final_pctx}: 'reason' is required"
+            msg = f"{pctx}: 'reason' is required"
             raise ValueError(msg)
-        final_pflags = parse_flags(repl.get("flags"))
+        pflags = parse_flags(repl.get("flags"))
         try:
-            re.compile(repl["pattern"], final_pflags)
+            _ = re.compile(repl["pattern"], pflags)
         except re.error as exc:
-            msg = f"{final_pctx}: invalid regex: {exc}"
+            msg = f"{pctx}: invalid regex: {exc}"
             raise ValueError(msg) from exc
 
 
-def validate_rule_ordering(filters: list[dict]) -> list[str]:
+def validate_rule_ordering(filters: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
     """Check for skip rules that shadow later rules with overlapping match criteria.
 
-    Returns list of error messages (empty if no problems).
+    Returns:
+        Tuple of error messages (empty if no problems).
     """
     errors: Final[list[str]] = []
     for i, rule_a in enumerate(filters):
         if rule_a.get("action", "skip") != "skip":
             continue
-        final_match_a = rule_a["match"]
+        match_a = rule_a["match"]
         for j in range(i + 1, len(filters)):
-            final_rule_b = filters[j]
-            final_match_b = final_rule_b["match"]
-            # Check if match_b is a subset of or identical to match_a
-            # (meaning everything match_b matches, match_a also matches)
-            if _match_is_subset(subset=final_match_b, superset=final_match_a):
-                errors.append(
+            rule_b = filters[j]
+            match_b = rule_b["match"]
+            if _match_is_subset(subset=match_b, superset=match_a):
+                shadow_msg = (
                     f"filters[{i}] (skip, reason: {rule_a['reason']!r}) shadows "
-                    f"filters[{j}] (reason: {final_rule_b['reason']!r}) — "
-                    f"the later rule will never fire. Reorder or adjust match criteria.",
+                    f"filters[{j}] (reason: {rule_b['reason']!r}) — "
+                    "the later rule will never fire. Reorder or adjust match criteria."
                 )
-    return errors
+                errors.append(shadow_msg)
+    return tuple(errors)
 
 
-def _match_is_subset(subset: dict, superset: dict) -> bool:
+def _match_is_subset(subset: Mapping[str, Any], superset: Mapping[str, Any]) -> bool:
     """Check if everything matched by 'subset' criteria is also matched by 'superset'.
 
-    A superset match has fewer or equal constraints — so subset must contain
+    A superset match has fewer or equal constraints -- so subset must contain
     all fields from superset with compatible operators.
+
+    Returns:
+        True if subset criteria are fully covered by superset criteria.
     """
     for field, operators in superset.items():
         if field not in subset:
             return False
-        final_sub_ops = subset[field]
-        for op, value in operators.items():
-            if op not in final_sub_ops:
+        sub_ops = subset[field]
+        super_ops = operators
+        for op, value in super_ops.items():
+            if op not in sub_ops:
                 return False
-            if final_sub_ops[op].lower() != value.lower():
+            if str(sub_ops[op]).lower() != str(value).lower():
                 return False
     return True
 
@@ -312,19 +324,19 @@ def _match_is_subset(subset: dict, superset: dict) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def evaluate_match(match_block: dict, metadata: dict[str, str]) -> bool:
+def evaluate_match(match_block: Mapping[str, Any], metadata: Mapping[str, str]) -> bool:
     for field, operators in match_block.items():
-        final_meta_value = metadata.get(field, "").lower()
+        meta_value = metadata.get(field, "").lower()
         for op, target in operators.items():
-            final_target_lower = target.lower()
-            if op == "contains" and final_target_lower not in final_meta_value:
+            target_lower = str(target).lower()
+            if op == "contains" and target_lower not in meta_value:
                 return False
-            if op == "not_contains" and final_target_lower in final_meta_value:
+            if op == "not_contains" and target_lower in meta_value:
                 return False
     return True
 
 
-def evaluate_llm_check(prompt_template: str, metadata: dict[str, str], content: str) -> bool:
+def evaluate_llm_check(prompt_template: str, metadata: Mapping[str, str], content: str) -> bool:
     final_title: Final = metadata.get("title", "")
     final_full_prompt: Final = f"{prompt_template}\n\nTitle: {final_title}\n\nContent:\n{content}"
     try:
@@ -341,10 +353,11 @@ def evaluate_llm_check(prompt_template: str, metadata: dict[str, str], content: 
                 },
             },
         )
-        final_parsed: Final = json.loads(final_response.text)
+        final_response_text: Final = final_response.text or ""
+        final_parsed: Final = json.loads(final_response_text)
         return bool(final_parsed.get("result", False))
-    except Exception as exc:
-        logging.exception("LLM check failed: %s", exc)
+    except Exception:
+        logging.exception("LLM check failed")
         return False
 
 
@@ -366,43 +379,43 @@ def clean_beehiiv_emphasis(text: str) -> str:
 
 def apply_general_cleaning(
     text: str,
-    metadata: dict[str, str],
-    config: dict,
-    stats: dict[str, dict],
-) -> str:
+    metadata: Mapping[str, str],
+    config: Mapping[str, Any],
+    stats: StatsDict,
+) -> tuple[str, StatsDict]:
     final_gc_config: Final = config.get("general_cleaning") or {}
     final_overrides: Final = final_gc_config.get("overrides") or []
 
+    # Build stats as dict, freeze at the end
+    stats_acc: dict[str, PMap[str, Any]] = dict(stats)
+
     def is_enabled(key: str) -> bool:
-        # Check per-source overrides first
         for override in final_overrides:
             if evaluate_match(override["match"], metadata) and key in override:
                 return bool(override[key])
-        # Then global config
         if key in final_gc_config:
             return bool(final_gc_config[key])
-        # Default: enabled
         return True
 
     def count_and_sub(pattern: str, replacement: str, text: str, key: str, flags: int = 0) -> str:
-        final_matches: Final = len(re.findall(pattern, text, flags=flags))
-        if final_matches > 0:
-            stats[key] = {"matches": final_matches}
+        match_count: Final = len(re.findall(pattern, text, flags=flags))
+        if match_count > 0:
+            stats_acc[key] = pmap({"matches": match_count})
         return re.sub(pattern, replacement, text, flags=flags)
 
     result: str = text
 
-    # Beehiiv plaintext conversion (must be first — changes text representation)
+    # Beehiiv plaintext conversion (must be first -- changes text representation)
     if is_enabled("beehiiv_plaintext_conversion") and metadata.get("source_kind") == "beehiiv":
         result = clean_beehiiv_to_plaintext(result)
-        stats["beehiiv_plaintext_conversion"] = {"applied": True}
+        stats_acc["beehiiv_plaintext_conversion"] = pmap({"applied": True})
 
     # Beehiiv emphasis removal (right after plaintext conversion)
     if is_enabled("beehiiv_emphasis_removal") and metadata.get("source_kind") == "beehiiv":
         final_before_emphasis: Final = result
         result = clean_beehiiv_emphasis(result)
         if result != final_before_emphasis:
-            stats["beehiiv_emphasis_removal"] = {"applied": True}
+            stats_acc["beehiiv_emphasis_removal"] = pmap({"applied": True})
 
     # URL removal
     if is_enabled("url_removal"):
@@ -434,12 +447,12 @@ def apply_general_cleaning(
         result = result.replace("<>", "")
         final_bracket_diff: Final = len(final_before_brackets) - len(result)
         if final_bracket_diff > 0:
-            stats["empty_bracket_removal"] = {"chars_removed": final_bracket_diff}
+            stats_acc["empty_bracket_removal"] = pmap({"chars_removed": final_bracket_diff})
 
     # Whitespace collapse
     if is_enabled("whitespace_collapse"):
         result = re.sub(r"[^\S\r\n]+", " ", result)
-        stats["whitespace_collapse"] = {"applied": True}
+        stats_acc["whitespace_collapse"] = pmap({"applied": True})
 
     # Unsubscribe removal
     if is_enabled("unsubscribe_removal"):
@@ -480,9 +493,9 @@ def apply_general_cleaning(
     # End-of-line punctuation (must be last)
     if is_enabled("end_of_line_punctuation"):
         result = re.sub(r"(\w)\s*(\r\n|\r|\n)", r"\1.\2", result)
-        stats["end_of_line_punctuation"] = {"applied": True}
+        stats_acc["end_of_line_punctuation"] = pmap({"applied": True})
 
-    return result
+    return result, pmap(stats_acc)
 
 
 # ---------------------------------------------------------------------------
@@ -490,31 +503,35 @@ def apply_general_cleaning(
 # ---------------------------------------------------------------------------
 
 
-def apply_text_removals(text: str, config: dict, stats: dict[str, dict]) -> str:
+def apply_text_removals(text: str, config: Mapping[str, Any], stats: StatsDict) -> tuple[str, StatsDict]:
     result: str = text
-    for removal in config.get("text_removals") or []:
-        final_pattern = removal["pattern"]
-        final_flags = parse_flags(removal.get("flags"))
-        final_reason = removal["reason"]
-        final_matches = len(re.findall(final_pattern, result, flags=final_flags))
-        if final_matches > 0:
-            result = re.sub(final_pattern, "", result, flags=final_flags)
-            stats[final_reason] = {"matches": final_matches}
-    return result
+    stats_acc: dict[str, PMap[str, Any]] = dict(stats)
+    final_removals: Final = config.get("text_removals") or []
+    for removal in final_removals:
+        pattern: str = removal["pattern"]
+        flags = parse_flags(removal.get("flags"))
+        reason: str = removal["reason"]
+        match_count = len(re.findall(pattern, result, flags=flags))
+        if match_count > 0:
+            result = re.sub(pattern, "", result, flags=flags)
+            stats_acc[reason] = pmap({"matches": match_count})
+    return result, pmap(stats_acc)
 
 
-def apply_text_replacements(text: str, config: dict, stats: dict[str, dict]) -> str:
+def apply_text_replacements(text: str, config: Mapping[str, Any], stats: StatsDict) -> tuple[str, StatsDict]:
     result: str = text
-    for repl in config.get("text_replacements") or []:
-        final_pattern = repl["pattern"]
-        final_replacement = repl["replacement"]
-        final_flags = parse_flags(repl.get("flags"))
-        final_reason = repl["reason"]
-        final_matches = len(re.findall(final_pattern, result, flags=final_flags))
-        if final_matches > 0:
-            result = re.sub(final_pattern, final_replacement, result, flags=final_flags)
-            stats[final_reason] = {"matches": final_matches}
-    return result
+    stats_acc: dict[str, PMap[str, Any]] = dict(stats)
+    final_repls: Final = config.get("text_replacements") or []
+    for repl in final_repls:
+        pattern: str = repl["pattern"]
+        replacement: str = repl["replacement"]
+        flags = parse_flags(repl.get("flags"))
+        reason: str = repl["reason"]
+        match_count = len(re.findall(pattern, result, flags=flags))
+        if match_count > 0:
+            result = re.sub(pattern, replacement, result, flags=flags)
+            stats_acc[reason] = pmap({"matches": match_count})
+    return result, pmap(stats_acc)
 
 
 # ---------------------------------------------------------------------------
@@ -522,33 +539,38 @@ def apply_text_replacements(text: str, config: dict, stats: dict[str, dict]) -> 
 # ---------------------------------------------------------------------------
 
 
-def load_today_stats() -> dict:
-    final_today: Final = datetime.now().strftime("%Y-%m-%d")
+def load_today_stats() -> YamlDict:
+    final_today: Final = datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%d")
     final_stats_path: Final = pathlib.Path(STATS_DIR) / f"{final_today}.json"
     if final_stats_path.exists():
-        return json.loads(final_stats_path.read_text(encoding="utf-8"))
-    return {}
+        final_loaded: Final = json.loads(final_stats_path.read_text(encoding="utf-8"))
+        return freeze(final_loaded)
+    return pmap()
 
 
-def save_stats(stats: dict) -> None:
-    final_today: Final = datetime.now().strftime("%Y-%m-%d")
+def save_stats(stats: YamlDict) -> None:
+    final_today: Final = datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%d")
     final_stats_path: Final = pathlib.Path(STATS_DIR) / f"{final_today}.json"
     final_stats_path.parent.mkdir(parents=True, exist_ok=True)
-    final_stats_path.write_text(
-        json.dumps(stats, indent=2, ensure_ascii=False) + "\n",
+    _ = final_stats_path.write_text(
+        json.dumps(thaw(stats), indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
 
 
 def rotate_stats() -> None:
-    final_cutoff: Final = datetime.now() - timedelta(days=STATS_RETENTION_DAYS)
+    final_cutoff: Final = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(
+        days=STATS_RETENTION_DAYS,
+    )
     final_stats_path: Final = pathlib.Path(STATS_DIR)
     if not final_stats_path.exists():
         return
     for stats_file in final_stats_path.glob("*.json"):
         try:
-            final_file_date = datetime.strptime(stats_file.stem, "%Y-%m-%d")
-            if final_file_date < final_cutoff:
+            file_date = datetime.datetime.strptime(stats_file.stem, "%Y-%m-%d").replace(
+                tzinfo=datetime.UTC,
+            )
+            if file_date < final_cutoff:
                 stats_file.unlink()
                 logging.info("Rotated old stats file: %s", stats_file.name)
         except ValueError:
@@ -562,15 +584,13 @@ def rotate_stats() -> None:
 
 def write_metadata_and_content(
     filepath: pathlib.Path,
-    metadata: dict[str, str],
+    metadata: Mapping[str, str],
     content: str,
 ) -> None:
-    final_meta_lines: Final = [
-        f"META_{key.upper()}: {value}" for key, value in metadata.items()
-    ]
+    final_meta_lines: Final = [f"META_{key.upper()}: {value}" for key, value in metadata.items()]
     final_meta_block: Final = "\n".join(final_meta_lines)
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    filepath.write_text(
+    _ = filepath.write_text(
         final_meta_block + "\n\n" + content,
         encoding="utf-8",
     )
@@ -581,138 +601,161 @@ def write_metadata_and_content(
 # ---------------------------------------------------------------------------
 
 
-def load_config() -> dict:
+def load_config() -> YamlDict:
     final_config_path: Final = pathlib.Path(CONFIG_FILE)
     if not final_config_path.exists():
         logging.info("No filters.yaml found; using defaults (no filters, no removals)")
-        return {}
+        return pmap()
     final_raw: Final = final_config_path.read_text(encoding="utf-8")
-    final_config: Final = yaml.safe_load(final_raw) or {}
+    final_parsed: Final = yaml.safe_load(final_raw) or {}
+    final_config: Final[YamlDict] = freeze(final_parsed)
     validate_config(final_config)
     return final_config
 
 
-def process_file(filepath: pathlib.Path, config: dict, all_stats: dict) -> None:
+def _build_file_stats(filename: str, chars_before: int) -> dict[str, Any]:
+    """Build the initial mutable file stats dict. Frozen via pmap() at return boundaries.
+
+    Returns:
+        Dict with initial stats keys, ready for mutation before freeze.
+    """
+    return {
+        "file": filename,
+        "raw_archive": None,
+        "cleaned_archive": None,
+        "filtered_archive": None,
+        "filters_checked": pvector(),
+        "filters_matched": pvector(),
+        "text_removals": pmap(),
+        "text_replacements": pmap(),
+        "general_cleaning": pmap(),
+        "outcome": None,
+        "chars_before": chars_before,
+        "chars_after": None,
+    }
+
+
+def process_file(
+    filepath: pathlib.Path,
+    config: YamlDict,
+    all_stats: YamlDict,
+) -> YamlDict:
     final_filename: Final = filepath.name
     logging.info("Processing: %s", final_filename)
 
     # Read and parse
     final_raw_text: Final = filepath.read_text(encoding="utf-8")
-    final_metadata: dict[str, str]
+    final_metadata: PMap[str, str]
     final_metadata, final_content_raw = split_metadata(final_raw_text)
-    final_timestamp: Final = datetime.now().isoformat(timespec="seconds")
+    final_timestamp: Final = datetime.datetime.now(tz=datetime.UTC).isoformat(timespec="seconds")
 
-    # Initialize stats entry
-    final_file_stats: Final[dict] = {
-        "file": final_filename,
-        "raw_archive": None,
-        "cleaned_archive": None,
-        "filtered_archive": None,
-        "filters_checked": [],
-        "filters_matched": [],
-        "text_removals": {},
-        "text_replacements": {},
-        "general_cleaning": {},
-        "outcome": None,
-        "chars_before": len(final_content_raw),
-        "chars_after": None,
-    }
+    # Build stats as mutable dict, freeze at return boundaries
+    file_stats: Final = _build_file_stats(final_filename, len(final_content_raw))
 
     # --- Run filters ---
-    final_filters: Final = config.get("filters") or []
+    final_filters: Final = config.get("filters") or pvector()
     skip_file: bool = False
-    final_filter_reason: str = ""
+    filter_reason: str = ""
+
+    checked_list: PVector[str] = pvector()
+    matched_list: PVector[str] = pvector()
 
     for filt in final_filters:
-        final_reason = filt["reason"]
-        final_action = filt.get("action", "skip")
+        reason: str = filt["reason"]
+        action: str = filt.get("action", "skip")
 
         if not evaluate_match(filt["match"], final_metadata):
-            final_file_stats["filters_checked"].append(final_reason)
+            checked_list = checked_list.append(reason)
             continue
 
-        # Match block passed — check LLM if needed
         if "llm_check" in filt:
-            final_llm_result = evaluate_llm_check(
+            llm_result: bool = evaluate_llm_check(
                 filt["llm_check"],
                 final_metadata,
                 final_content_raw,
             )
-            if not final_llm_result:
-                final_file_stats["filters_checked"].append(final_reason)
+            if not llm_result:
+                checked_list = checked_list.append(reason)
                 continue
 
         # Filter matched
-        final_file_stats["filters_checked"].append(final_reason)
-        final_file_stats["filters_matched"].append(final_reason)
+        checked_list = checked_list.append(reason)
+        matched_list = matched_list.append(reason)
 
-        if final_action == "notify":
-            final_notify_config = filt["notify"]
+        if action == "notify":
+            notify_config = filt["notify"]
             send_gotify_notification(
-                title=final_notify_config["title"],
+                title=str(notify_config["title"]),
                 message=f"{final_filename}\n\n{final_metadata.get('title', '')}",
-                priority=final_notify_config["priority"],
+                priority=int(notify_config["priority"]),
             )
             continue
 
-        # action == skip
         skip_file = True
-        final_filter_reason = final_reason
+        filter_reason = reason
         break
+
+    file_stats["filters_checked"] = checked_list
+    file_stats["filters_matched"] = matched_list
 
     if skip_file:
         # Write to filtered dir with reason
-        final_filtered_metadata: Final = {**final_metadata, "filtered_reason": final_filter_reason}
+        final_filtered_metadata: Final[PMap[str, str]] = final_metadata.set("filtered_reason", filter_reason)
         final_filtered_path: Final = pathlib.Path(FILTERED_DIR) / final_filename
         write_metadata_and_content(final_filtered_path, final_filtered_metadata, final_content_raw)
 
         # Archive raw
         final_raw_archive_path: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
         final_raw_archive_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(str(filepath), str(final_raw_archive_path))
+        _ = shutil.copy2(str(filepath), str(final_raw_archive_path))
 
-        final_file_stats["filtered_archive"] = str(final_filtered_path)
-        final_file_stats["raw_archive"] = str(final_raw_archive_path)
-        final_file_stats["outcome"] = "filtered"
-        final_file_stats["chars_after"] = len(final_content_raw)
-        all_stats[final_timestamp] = final_file_stats
+        file_stats["filtered_archive"] = str(final_filtered_path)
+        file_stats["raw_archive"] = str(final_raw_archive_path)
+        file_stats["outcome"] = "filtered"
+        file_stats["chars_after"] = len(final_content_raw)
 
         # Delete raw input
         filepath.unlink()
-        logging.info("Filtered: %s (reason: %s)", final_filename, final_filter_reason)
-        return
+        logging.info("Filtered: %s (reason: %s)", final_filename, filter_reason)
+        return all_stats.set(final_timestamp, freeze(file_stats))
 
     # --- Apply cleaning ---
-    final_gc_stats: Final[dict[str, dict]] = {}
-    cleaned_text: str = apply_general_cleaning(
+    cleaned_text: str
+    final_gc_stats: StatsDict
+    cleaned_text, final_gc_stats = apply_general_cleaning(
         final_content_raw,
         final_metadata,
         config,
-        final_gc_stats,
+        pmap(),
     )
-    final_file_stats["general_cleaning"] = final_gc_stats
+    file_stats["general_cleaning"] = final_gc_stats
 
     # YAML text removals
-    final_removal_stats: Final[dict[str, dict]] = {}
-    cleaned_text = apply_text_removals(cleaned_text, config, final_removal_stats)
-    final_file_stats["text_removals"] = final_removal_stats
+    final_removal_stats: StatsDict
+    cleaned_text, final_removal_stats = apply_text_removals(
+        cleaned_text,
+        config,
+        pmap(),
+    )
+    file_stats["text_removals"] = final_removal_stats
 
     # YAML text replacements
-    final_replacement_stats: Final[dict[str, dict]] = {}
-    cleaned_text = apply_text_replacements(cleaned_text, config, final_replacement_stats)
-    final_file_stats["text_replacements"] = final_replacement_stats
+    final_replacement_stats: StatsDict
+    cleaned_text, final_replacement_stats = apply_text_replacements(
+        cleaned_text,
+        config,
+        pmap(),
+    )
+    file_stats["text_replacements"] = final_replacement_stats
 
     # Prepend and append author + title
     final_from_name: Final = final_metadata.get("from", "").strip()
     final_title: Final = final_metadata.get("title", "").strip()
-    final_header: Final = (
-        (f"{final_from_name}.\n" if final_from_name else "")
-        + (f"{final_title}.\n" if final_title else "")
+    final_header: Final = (f"{final_from_name}.\n" if final_from_name else "") + (
+        f"{final_title}.\n" if final_title else ""
     )
     final_footer: Final = (
-        "\n\n"
-        + (f"{final_from_name}.\n" if final_from_name else "")
-        + (f"{final_title}.\n" if final_title else "")
+        "\n\n" + (f"{final_from_name}.\n" if final_from_name else "") + (f"{final_title}.\n" if final_title else "")
     )
     if final_header:
         cleaned_text = final_header + "\n" + cleaned_text
@@ -722,19 +765,18 @@ def process_file(filepath: pathlib.Path, config: dict, all_stats: dict) -> None:
     # Check too-big
     if len(cleaned_text) >= CHARACTER_LIMIT:
         final_toobig_reason: Final = f"Content too large: {len(cleaned_text)} chars (limit: {CHARACTER_LIMIT})"
-        final_filtered_metadata_big: Final = {**final_metadata, "filtered_reason": final_toobig_reason}
+        final_filtered_metadata_big: Final[PMap[str, str]] = final_metadata.set("filtered_reason", final_toobig_reason)
         final_filtered_path_big: Final = pathlib.Path(FILTERED_DIR) / final_filename
         write_metadata_and_content(final_filtered_path_big, final_filtered_metadata_big, cleaned_text)
 
         final_raw_archive_path_big: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
         final_raw_archive_path_big.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(str(filepath), str(final_raw_archive_path_big))
+        _ = shutil.copy2(str(filepath), str(final_raw_archive_path_big))
 
-        final_file_stats["filtered_archive"] = str(final_filtered_path_big)
-        final_file_stats["raw_archive"] = str(final_raw_archive_path_big)
-        final_file_stats["outcome"] = "filtered_too_big"
-        final_file_stats["chars_after"] = len(cleaned_text)
-        all_stats[final_timestamp] = final_file_stats
+        file_stats["filtered_archive"] = str(final_filtered_path_big)
+        file_stats["raw_archive"] = str(final_raw_archive_path_big)
+        file_stats["outcome"] = "filtered_too_big"
+        file_stats["chars_after"] = len(cleaned_text)
 
         filepath.unlink()
         logging.info("Filtered (too big): %s (%d chars)", final_filename, len(cleaned_text))
@@ -742,24 +784,23 @@ def process_file(filepath: pathlib.Path, config: dict, all_stats: dict) -> None:
             "Skipping large text-to-speech content",
             f"{final_filename}: {len(cleaned_text)} chars exceeds {CHARACTER_LIMIT} limit.",
         )
-        return
+        return all_stats.set(final_timestamp, freeze(file_stats))
 
     # Check empty
     if not cleaned_text.strip():
         final_empty_reason: Final = "Content empty after cleaning"
-        final_filtered_metadata_empty: Final = {**final_metadata, "filtered_reason": final_empty_reason}
+        final_filtered_metadata_empty: Final[PMap[str, str]] = final_metadata.set("filtered_reason", final_empty_reason)
         final_filtered_path_empty: Final = pathlib.Path(FILTERED_DIR) / final_filename
         write_metadata_and_content(final_filtered_path_empty, final_filtered_metadata_empty, "")
 
         final_raw_archive_path_empty: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
         final_raw_archive_path_empty.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(str(filepath), str(final_raw_archive_path_empty))
+        _ = shutil.copy2(str(filepath), str(final_raw_archive_path_empty))
 
-        final_file_stats["filtered_archive"] = str(final_filtered_path_empty)
-        final_file_stats["raw_archive"] = str(final_raw_archive_path_empty)
-        final_file_stats["outcome"] = "filtered_empty"
-        final_file_stats["chars_after"] = 0
-        all_stats[final_timestamp] = final_file_stats
+        file_stats["filtered_archive"] = str(final_filtered_path_empty)
+        file_stats["raw_archive"] = str(final_raw_archive_path_empty)
+        file_stats["outcome"] = "filtered_empty"
+        file_stats["chars_after"] = 0
 
         filepath.unlink()
         logging.info("Filtered (empty after cleaning): %s", final_filename)
@@ -767,7 +808,7 @@ def process_file(filepath: pathlib.Path, config: dict, all_stats: dict) -> None:
             "Skipping empty text-to-speech content",
             f"{final_filename}: empty after cleaning.",
         )
-        return
+        return all_stats.set(final_timestamp, freeze(file_stats))
 
     # --- Write outputs ---
     # Write cleaned output
@@ -777,20 +818,19 @@ def process_file(filepath: pathlib.Path, config: dict, all_stats: dict) -> None:
     # Archive raw
     final_raw_archive_final: Final = pathlib.Path(RAW_ARCHIVE_DIR) / final_filename
     final_raw_archive_final.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(str(filepath), str(final_raw_archive_final))
+    _ = shutil.copy2(str(filepath), str(final_raw_archive_final))
 
     # Archive cleaned
     final_cleaned_archive: Final = pathlib.Path(CLEANED_ARCHIVE_DIR) / final_filename
     final_cleaned_archive.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(str(final_cleaned_path), str(final_cleaned_archive))
+    _ = shutil.copy2(str(final_cleaned_path), str(final_cleaned_archive))
 
-    final_file_stats["raw_archive"] = str(final_raw_archive_final)
-    final_file_stats["cleaned_archive"] = str(final_cleaned_archive)
-    final_file_stats["outcome"] = "cleaned"
-    final_file_stats["chars_after"] = len(cleaned_text)
-    all_stats[final_timestamp] = final_file_stats
+    file_stats["raw_archive"] = str(final_raw_archive_final)
+    file_stats["cleaned_archive"] = str(final_cleaned_archive)
+    file_stats["outcome"] = "cleaned"
+    file_stats["chars_after"] = len(cleaned_text)
 
-    # Delete raw input (last step — only after all writes succeeded)
+    # Delete raw input (last step -- only after all writes succeeded)
     filepath.unlink()
     logging.info(
         "Cleaned: %s (%d -> %d chars)",
@@ -798,6 +838,7 @@ def process_file(filepath: pathlib.Path, config: dict, all_stats: dict) -> None:
         len(final_content_raw),
         len(cleaned_text),
     )
+    return all_stats.set(final_timestamp, freeze(file_stats))
 
 
 def process_files() -> None:
@@ -812,9 +853,13 @@ def process_files() -> None:
     final_config: Final = load_config()
 
     # Validate rule ordering
-    final_filters: Final = final_config.get("filters") or []
+    final_filters: Final = final_config.get("filters") or pvector()
     final_ordering_errors: Final = validate_rule_ordering(final_filters)
-    final_shadowed_matches: Final[list[dict]] = []
+    final_shadowed_matches: Final[PVector[Mapping[str, Any]]] = pvector(
+        final_filters[int(error.split("filters[")[1].split("]")[0])]["match"]
+        for error in final_ordering_errors
+        if final_filters[int(error.split("filters[")[1].split("]")[0])].get("action", "skip") == "skip"
+    )
 
     if final_ordering_errors:
         final_error_msg: Final = "Filter rule ordering issues:\n" + "\n".join(final_ordering_errors)
@@ -824,27 +869,19 @@ def process_files() -> None:
             final_error_msg + "\n\nAffected files will be left in text-input-raw/ until this is fixed.",
             priority=9,
         )
-        # Collect the match blocks from skip rules that shadow later rules
-        for error in final_ordering_errors:
-            # Extract the index of the skip rule from the error message
-            final_idx_str = error.split("filters[")[1].split("]")[0]
-            final_idx = int(final_idx_str)
-            final_shadowed_matches.append(final_filters[final_idx]["match"])
 
     # Load today's stats (append to existing if re-run)
-    final_all_stats: Final = load_today_stats()
+    all_stats: YamlDict = load_today_stats()
 
     # Process files
     final_txt_files: Final = sorted(pathlib.Path(RAW_INPUT_DIR).glob("*.txt"))
     for txt_file in final_txt_files:
         # Check if this file matches a shadowed skip rule
         if final_shadowed_matches:
-            final_raw_text_check = txt_file.read_text(encoding="utf-8")
-            final_meta_check = split_metadata(final_raw_text_check)[0]
-            final_is_shadowed = any(
-                evaluate_match(match, final_meta_check) for match in final_shadowed_matches
-            )
-            if final_is_shadowed:
+            raw_text_check = txt_file.read_text(encoding="utf-8")
+            meta_check = split_metadata(raw_text_check)[0]
+            is_shadowed = any(evaluate_match(match, meta_check) for match in final_shadowed_matches)
+            if is_shadowed:
                 logging.warning(
                     "Skipping %s due to rule ordering conflict (left in raw)",
                     txt_file.name,
@@ -852,12 +889,12 @@ def process_files() -> None:
                 continue
 
         try:
-            process_file(txt_file, final_config, final_all_stats)
+            all_stats = process_file(txt_file, final_config, all_stats)
         except Exception:
             logging.exception("Error processing %s — leaving in raw for retry", txt_file.name)
             continue
 
-    save_stats(final_all_stats)
+    save_stats(all_stats)
 
 
 if __name__ == "__main__":

--- a/prepare-text/pyproject.toml
+++ b/prepare-text/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "beautifulsoup4>=4.12.3",
     "google-genai>=1.0.0",
     "markdown>=3.7",
+    "pyrsistent>=0.20.0",
     "pyyaml>=6.0",
     "requests>=2.32.3",
 ]
@@ -15,6 +16,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "basedpyright>=1.20.0",
+    "pytest>=8.0",
     "ruff>=0.7.0",
     "types-beautifulsoup4>=4.12.0",
     "types-pyyaml>=6.0",

--- a/prepare-text/test_prepare_text.py
+++ b/prepare-text/test_prepare_text.py
@@ -1,0 +1,671 @@
+# pyright: reportExplicitAny=false, reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+"""Unit tests for prepare_text.py."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+import pytest
+from pyrsistent import PMap, pmap, pvector
+
+from prepare_text import (
+    _match_is_subset,
+    apply_general_cleaning,
+    apply_text_removals,
+    apply_text_replacements,
+    clean_beehiiv_emphasis,
+    clean_beehiiv_to_plaintext,
+    evaluate_match,
+    parse_flags,
+    split_metadata,
+    validate_config,
+    validate_match_block,
+    validate_rule_ordering,
+)
+
+type YamlDict = PMap[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# split_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestSplitMetadata:
+    def test_basic_metadata(self) -> None:
+        raw = "META_FROM: Author Name\nMETA_TITLE: Some Title\n\nBody text here."
+        metadata, content = split_metadata(raw)
+        assert metadata == pmap({"from": "Author Name", "title": "Some Title"})
+        assert content == "Body text here."
+
+    def test_no_metadata(self) -> None:
+        raw = "Just plain text without metadata."
+        metadata, content = split_metadata(raw)
+        assert metadata == pmap()
+        assert content == raw
+
+    def test_multiline_metadata_value(self) -> None:
+        raw = "META_FROM: Author Name\n  continued value\nMETA_TITLE: Title\n\nBody."
+        metadata, content = split_metadata(raw)
+        assert metadata["from"] == "Author Name continued value"
+        assert metadata["title"] == "Title"
+        assert content == "Body."
+
+    def test_empty_content(self) -> None:
+        raw = "META_FROM: Author\nMETA_TITLE: Title\n\n"
+        metadata, content = split_metadata(raw)
+        assert metadata == pmap({"from": "Author", "title": "Title"})
+        assert not content
+
+    def test_tab_continuation(self) -> None:
+        raw = "META_FROM: Author\n\tcontinued\n\nBody."
+        metadata, _content = split_metadata(raw)
+        assert metadata["from"] == "Author continued"
+
+    def test_multiple_meta_fields(self) -> None:
+        raw = (
+            "META_FROM: Author\n"
+            "META_TITLE: Title\n"
+            "META_SOURCE_URL: https://example.com\n"
+            "META_SOURCE_KIND: substack\n"
+            "META_SOURCE_NAME: Blog\n"
+            "META_INTAKE_TYPE: email\n"
+            "\n"
+            "Content."
+        )
+        metadata, content = split_metadata(raw)
+        assert len(metadata) == 6
+        assert metadata["source_url"] == "https://example.com"
+        assert metadata["intake_type"] == "email"
+        assert content == "Content."
+
+
+# ---------------------------------------------------------------------------
+# parse_flags
+# ---------------------------------------------------------------------------
+
+
+class TestParseFlags:
+    def test_none_returns_zero(self) -> None:
+        assert parse_flags(None) == 0
+
+    def test_single_string(self) -> None:
+        assert parse_flags("ignorecase") == re.IGNORECASE
+
+    def test_list_of_flags(self) -> None:
+        result = parse_flags(["ignorecase", "multiline", "dotall"])
+        assert result == (re.IGNORECASE | re.MULTILINE | re.DOTALL)
+
+    def test_invalid_flag_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid flag"):
+            parse_flags("nonexistent")
+
+    def test_single_dotall(self) -> None:
+        assert parse_flags("dotall") == re.DOTALL
+
+
+# ---------------------------------------------------------------------------
+# validate_match_block
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMatchBlock:
+    def test_valid_block(self) -> None:
+        validate_match_block(pmap({"from": pmap({"contains": "Author"})}), "test")
+
+    def test_empty_block_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty dict"):
+            validate_match_block(pmap(), "test")
+
+    def test_unknown_field_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown match field"):
+            validate_match_block(pmap({"bogus": pmap({"contains": "x"})}), "test")
+
+    def test_unknown_operator_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown operator"):
+            validate_match_block(pmap({"from": pmap({"starts_with": "x"})}), "test")
+
+    def test_operators_must_be_dict(self) -> None:
+        with pytest.raises(ValueError, match="must be a dict with operators"):
+            validate_match_block(pmap({"from": "Author"}), "test")
+
+    def test_multiple_fields(self) -> None:
+        validate_match_block(
+            pmap({"from": pmap({"contains": "Author"}), "title": pmap({"not_contains": "Draft"})}),
+            "test",
+        )
+
+
+# ---------------------------------------------------------------------------
+# validate_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfig:
+    def test_empty_config(self) -> None:
+        validate_config(pmap())
+
+    def test_unknown_top_level_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown top-level key"):
+            validate_config(pmap({"bogus": True}))
+
+    def test_filter_missing_match_raises(self) -> None:
+        with pytest.raises(ValueError, match="'match' is required"):
+            validate_config(pmap({"filters": pvector([pmap({"reason": "test"})])}))
+
+    def test_filter_missing_reason_raises(self) -> None:
+        with pytest.raises(ValueError, match="'reason' is required"):
+            validate_config(pmap({"filters": pvector([pmap({"match": pmap({"from": pmap({"contains": "x"})})})])}))
+
+    def test_invalid_action_raises(self) -> None:
+        config: YamlDict = pmap(
+            {
+                "filters": pvector(
+                    [
+                        pmap({"match": pmap({"from": pmap({"contains": "x"})}), "reason": "test", "action": "delete"}),
+                    ]
+                ),
+            }
+        )
+        with pytest.raises(ValueError, match="invalid action"):
+            validate_config(config)
+
+    def test_notify_without_notify_block_raises(self) -> None:
+        config: YamlDict = pmap(
+            {
+                "filters": pvector(
+                    [
+                        pmap({"match": pmap({"from": pmap({"contains": "x"})}), "reason": "test", "action": "notify"}),
+                    ]
+                ),
+            }
+        )
+        with pytest.raises(ValueError, match="requires a 'notify' block"):
+            validate_config(config)
+
+    def test_notify_block_missing_priority_raises(self) -> None:
+        config: YamlDict = pmap(
+            {
+                "filters": pvector(
+                    [
+                        pmap(
+                            {
+                                "match": pmap({"from": pmap({"contains": "x"})}),
+                                "reason": "test",
+                                "action": "notify",
+                                "notify": pmap({"title": "Alert"}),
+                            }
+                        ),
+                    ]
+                ),
+            }
+        )
+        with pytest.raises(ValueError, match="requires 'priority'"):
+            validate_config(config)
+
+    def test_valid_full_config(self) -> None:
+        config: YamlDict = pmap(
+            {
+                "filters": pvector(
+                    [
+                        pmap(
+                            {
+                                "match": pmap({"from": pmap({"contains": "Author"})}),
+                                "reason": "test filter",
+                                "action": "notify",
+                                "notify": pmap({"title": "Alert", "priority": 5}),
+                            }
+                        ),
+                    ]
+                ),
+                "general_cleaning": pmap({"url_removal": False}),
+                "text_removals": pvector(
+                    [
+                        pmap({"pattern": "^Ad$", "flags": "multiline", "reason": "ads"}),
+                    ]
+                ),
+                "text_replacements": pvector(
+                    [
+                        pmap(
+                            {
+                                "pattern": "Keynesian",
+                                "replacement": "Cainzeean",
+                                "flags": "ignorecase",
+                                "reason": "pronunciation",
+                            }
+                        ),
+                    ]
+                ),
+            }
+        )
+        validate_config(config)
+
+    def test_invalid_regex_in_removals_raises(self) -> None:
+        config: YamlDict = pmap(
+            {
+                "text_removals": pvector([pmap({"pattern": "[invalid", "reason": "broken"})]),
+            }
+        )
+        with pytest.raises(ValueError, match="invalid regex"):
+            validate_config(config)
+
+    def test_invalid_regex_in_replacements_raises(self) -> None:
+        config: YamlDict = pmap(
+            {
+                "text_replacements": pvector([pmap({"pattern": "[invalid", "replacement": "x", "reason": "broken"})]),
+            }
+        )
+        with pytest.raises(ValueError, match="invalid regex"):
+            validate_config(config)
+
+    def test_general_cleaning_unknown_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown key"):
+            validate_config(pmap({"general_cleaning": pmap({"bogus_setting": True})}))
+
+    def test_general_cleaning_non_bool_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be a boolean"):
+            validate_config(pmap({"general_cleaning": pmap({"url_removal": "yes"})}))
+
+
+# ---------------------------------------------------------------------------
+# validate_rule_ordering
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRuleOrdering:
+    def test_no_shadowing(self) -> None:
+        filters = pvector(
+            [
+                pmap({"match": pmap({"from": pmap({"contains": "Author A"})}), "action": "skip", "reason": "skip A"}),
+                pmap({"match": pmap({"from": pmap({"contains": "Author B"})}), "action": "skip", "reason": "skip B"}),
+            ]
+        )
+        assert validate_rule_ordering(filters) == ()
+
+    def test_shadow_detected(self) -> None:
+        filters = pvector(
+            [
+                pmap(
+                    {
+                        "match": pmap({"source_url": pmap({"contains": "example"})}),
+                        "action": "skip",
+                        "reason": "skip all example",
+                    }
+                ),
+                pmap(
+                    {
+                        "match": pmap(
+                            {
+                                "source_url": pmap({"contains": "example"}),
+                                "title": pmap({"contains": "special"}),
+                            }
+                        ),
+                        "action": "notify",
+                        "reason": "notify special example",
+                    }
+                ),
+            ]
+        )
+        errors = validate_rule_ordering(filters)
+        assert len(errors) == 1
+        assert "shadows" in errors[0]
+
+    def test_notify_before_skip_no_shadow(self) -> None:
+        filters = pvector(
+            [
+                pmap(
+                    {
+                        "match": pmap({"source_url": pmap({"contains": "example"})}),
+                        "action": "notify",
+                        "reason": "notify example",
+                    }
+                ),
+                pmap(
+                    {
+                        "match": pmap({"source_url": pmap({"contains": "example"})}),
+                        "action": "skip",
+                        "reason": "skip example",
+                    }
+                ),
+            ]
+        )
+        assert validate_rule_ordering(filters) == ()
+
+
+# ---------------------------------------------------------------------------
+# _match_is_subset
+# ---------------------------------------------------------------------------
+
+
+class TestMatchIsSubset:
+    def test_identical_matches(self) -> None:
+        match: Mapping[str, Any] = pmap({"from": pmap({"contains": "Author"})})
+        assert _match_is_subset(subset=match, superset=match) is True
+
+    def test_subset_has_extra_constraint(self) -> None:
+        superset: Mapping[str, Any] = pmap({"from": pmap({"contains": "Author"})})
+        subset: Mapping[str, Any] = pmap({"from": pmap({"contains": "Author"}), "title": pmap({"contains": "News"})})
+        assert _match_is_subset(subset=subset, superset=superset) is True
+
+    def test_not_subset_different_value(self) -> None:
+        superset: Mapping[str, Any] = pmap({"from": pmap({"contains": "Author A"})})
+        subset: Mapping[str, Any] = pmap({"from": pmap({"contains": "Author B"})})
+        assert _match_is_subset(subset=subset, superset=superset) is False
+
+    def test_not_subset_missing_field(self) -> None:
+        superset: Mapping[str, Any] = pmap(
+            {
+                "from": pmap({"contains": "Author"}),
+                "title": pmap({"contains": "News"}),
+            }
+        )
+        subset: Mapping[str, Any] = pmap({"from": pmap({"contains": "Author"})})
+        assert _match_is_subset(subset=subset, superset=superset) is False
+
+    def test_case_insensitive_comparison(self) -> None:
+        superset: Mapping[str, Any] = pmap({"from": pmap({"contains": "AUTHOR"})})
+        subset: Mapping[str, Any] = pmap({"from": pmap({"contains": "author"})})
+        assert _match_is_subset(subset=subset, superset=superset) is True
+
+
+# ---------------------------------------------------------------------------
+# evaluate_match
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateMatch:
+    def test_contains_match(self) -> None:
+        match: Mapping[str, Any] = pmap({"from": pmap({"contains": "author"})})
+        metadata: Mapping[str, str] = pmap({"from": "The Author Name", "title": "Article"})
+        assert evaluate_match(match, metadata) is True
+
+    def test_contains_no_match(self) -> None:
+        match: Mapping[str, Any] = pmap({"from": pmap({"contains": "nobody"})})
+        metadata: Mapping[str, str] = pmap({"from": "The Author Name"})
+        assert evaluate_match(match, metadata) is False
+
+    def test_not_contains_match(self) -> None:
+        match: Mapping[str, Any] = pmap({"title": pmap({"not_contains": "draft"})})
+        metadata: Mapping[str, str] = pmap({"title": "Published Article"})
+        assert evaluate_match(match, metadata) is True
+
+    def test_not_contains_no_match(self) -> None:
+        match: Mapping[str, Any] = pmap({"title": pmap({"not_contains": "draft"})})
+        metadata: Mapping[str, str] = pmap({"title": "Draft Article"})
+        assert evaluate_match(match, metadata) is False
+
+    def test_multiple_conditions_all_must_match(self) -> None:
+        match: Mapping[str, Any] = pmap({"from": pmap({"contains": "author"}), "title": pmap({"contains": "news"})})
+        metadata: Mapping[str, str] = pmap({"from": "Author Name", "title": "Breaking News"})
+        assert evaluate_match(match, metadata) is True
+
+    def test_multiple_conditions_one_fails(self) -> None:
+        match: Mapping[str, Any] = pmap({"from": pmap({"contains": "author"}), "title": pmap({"contains": "sports"})})
+        metadata: Mapping[str, str] = pmap({"from": "Author Name", "title": "Breaking News"})
+        assert evaluate_match(match, metadata) is False
+
+    def test_missing_metadata_field(self) -> None:
+        match: Mapping[str, Any] = pmap({"source_url": pmap({"contains": "example.com"})})
+        metadata: Mapping[str, str] = pmap({"from": "Author"})
+        assert evaluate_match(match, metadata) is False
+
+    def test_case_insensitive(self) -> None:
+        match: Mapping[str, Any] = pmap({"from": pmap({"contains": "AUTHOR"})})
+        metadata: Mapping[str, str] = pmap({"from": "author name"})
+        assert evaluate_match(match, metadata) is True
+
+
+# ---------------------------------------------------------------------------
+# clean_beehiiv_to_plaintext
+# ---------------------------------------------------------------------------
+
+
+class TestCleanBeehiivToPlaintext:
+    def test_basic_markdown(self) -> None:
+        result = clean_beehiiv_to_plaintext("**bold** and _italic_")
+        assert "bold" in result
+        assert "italic" in result
+        assert "**" not in result
+        assert "_" not in result or result.count("_") == 0
+
+    def test_plain_text_passthrough(self) -> None:
+        result = clean_beehiiv_to_plaintext("Just plain text.")
+        assert result.strip() == "Just plain text."
+
+
+# ---------------------------------------------------------------------------
+# clean_beehiiv_emphasis
+# ---------------------------------------------------------------------------
+
+
+class TestCleanBeehiivEmphasis:
+    def test_double_underscore(self) -> None:
+        assert clean_beehiiv_emphasis("__bold text__") == "bold text"
+
+    def test_single_underscore(self) -> None:
+        assert clean_beehiiv_emphasis("_italic text_") == "italic text"
+
+    def test_mixed(self) -> None:
+        result = clean_beehiiv_emphasis("__bold__ and _italic_")
+        assert result == "bold and italic"
+
+    def test_no_emphasis(self) -> None:
+        assert clean_beehiiv_emphasis("no emphasis here") == "no emphasis here"
+
+
+# ---------------------------------------------------------------------------
+# apply_general_cleaning
+# ---------------------------------------------------------------------------
+
+
+class TestApplyGeneralCleaning:
+    def test_url_removal(self) -> None:
+        text = "Visit https://example.com/page for more info."
+        result, stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "https://example.com" not in result
+        assert "url_removal" in stats
+
+    def test_whitespace_collapse(self) -> None:
+        text = "too    many    spaces"
+        result, stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "too many spaces" in result
+        assert "whitespace_collapse" in stats
+
+    def test_unsubscribe_removal(self) -> None:
+        text = "Article content.\n\nUnsubscribe from this list."
+        result, _stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "Unsubscribe" not in result
+
+    def test_legal_bracket_unwrap(self) -> None:
+        text = "[t]he court ruled that [T]he defendant"
+        result, _stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "[t]" not in result
+        assert "[T]" not in result
+        assert "the court" in result
+
+    def test_disabled_cleaning(self) -> None:
+        text = "Visit https://example.com for info."
+        config: Mapping[str, Any] = pmap({"general_cleaning": pmap({"url_removal": False})})
+        result, _stats = apply_general_cleaning(text, pmap(), config, pmap())
+        assert "https://example.com" in result
+
+    def test_end_of_line_punctuation(self) -> None:
+        text = "Line without period\nNext line"
+        result, _stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "period.\n" in result
+
+    def test_triple_dash_removal(self) -> None:
+        text = "Before --- After"
+        result, _stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "---" not in result
+
+    def test_empty_bracket_removal(self) -> None:
+        text = "Text with [] and () and <> markers."
+        result, _stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "[]" not in result
+        assert "()" not in result
+        assert "<>" not in result
+
+    def test_view_online_removal(self) -> None:
+        text = "View this post on the web at \n\nArticle starts here."
+        result, _stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert "View this post on the web" not in result
+
+    def test_standalone_at_removal(self) -> None:
+        text = "Before\n @ \nAfter"
+        result, _stats = apply_general_cleaning(text, pmap(), pmap(), pmap())
+        assert " @ " not in result
+
+    def test_override_for_specific_source(self) -> None:
+        text = "Visit https://example.com for info."
+        config: Mapping[str, Any] = pmap(
+            {
+                "general_cleaning": pmap(
+                    {
+                        "overrides": pvector(
+                            [
+                                pmap({"match": pmap({"from": pmap({"contains": "author"})}), "url_removal": False}),
+                            ]
+                        ),
+                    }
+                ),
+            }
+        )
+        result, _stats = apply_general_cleaning(text, pmap({"from": "Author Name"}), config, pmap())
+        assert "https://example.com" in result
+
+
+# ---------------------------------------------------------------------------
+# apply_text_removals
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTextRemovals:
+    def test_basic_removal(self) -> None:
+        config: Mapping[str, Any] = pmap(
+            {
+                "text_removals": pvector([pmap({"pattern": "^Advertisement$", "flags": "multiline", "reason": "ads"})]),
+            }
+        )
+        text = "Content\nAdvertisement\nMore content"
+        result, stats = apply_text_removals(text, config, pmap())
+        assert "Advertisement" not in result
+        assert "Content" in result
+        assert stats["ads"]["matches"] == 1
+
+    def test_no_match(self) -> None:
+        config: Mapping[str, Any] = pmap(
+            {
+                "text_removals": pvector([pmap({"pattern": "NONEXISTENT", "reason": "missing"})]),
+            }
+        )
+        text = "Normal content."
+        result, stats = apply_text_removals(text, config, pmap())
+        assert result == text
+        assert len(stats) == 0
+
+    def test_multiple_removals(self) -> None:
+        config: Mapping[str, Any] = pmap(
+            {
+                "text_removals": pvector(
+                    [
+                        pmap({"pattern": "^Ad$", "flags": "multiline", "reason": "ads"}),
+                        pmap({"pattern": "^Sponsored$", "flags": "multiline", "reason": "sponsored"}),
+                    ]
+                ),
+            }
+        )
+        text = "Content\nAd\nMore\nSponsored\nEnd"
+        result, stats = apply_text_removals(text, config, pmap())
+        assert "Ad" not in result.split("\n")
+        assert "Sponsored" not in result.split("\n")
+        assert stats["ads"]["matches"] == 1
+        assert stats["sponsored"]["matches"] == 1
+
+    def test_dotall_flag(self) -> None:
+        config: Mapping[str, Any] = pmap(
+            {
+                "text_removals": pvector([pmap({"pattern": "START.*END", "flags": "dotall", "reason": "block"})]),
+            }
+        )
+        text = "Before START\nmiddle\nEND After"
+        result, _stats = apply_text_removals(text, config, pmap())
+        assert "middle" not in result
+        assert "Before" in result
+        assert "After" in result
+
+    def test_empty_removals_list(self) -> None:
+        config: Mapping[str, Any] = pmap()
+        text = "Content."
+        result, _stats = apply_text_removals(text, config, pmap())
+        assert result == text
+
+
+# ---------------------------------------------------------------------------
+# apply_text_replacements
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTextReplacements:
+    def test_basic_replacement(self) -> None:
+        config: Mapping[str, Any] = pmap(
+            {
+                "text_replacements": pvector(
+                    [
+                        pmap(
+                            {
+                                "pattern": "Keynesian",
+                                "replacement": "Cainzeean",
+                                "flags": "ignorecase",
+                                "reason": "pronunciation",
+                            }
+                        ),
+                    ]
+                ),
+            }
+        )
+        text = "The Keynesian school of thought"
+        result, stats = apply_text_replacements(text, config, pmap())
+        assert "Cainzeean" in result
+        assert "Keynesian" not in result
+        assert stats["pronunciation"]["matches"] == 1
+
+    def test_no_match(self) -> None:
+        config: Mapping[str, Any] = pmap(
+            {
+                "text_replacements": pvector(
+                    [
+                        pmap({"pattern": "NONEXISTENT", "replacement": "X", "reason": "test"}),
+                    ]
+                ),
+            }
+        )
+        text = "Normal content."
+        result, stats = apply_text_replacements(text, config, pmap())
+        assert result == text
+        assert len(stats) == 0
+
+    def test_multiple_occurrences(self) -> None:
+        config: Mapping[str, Any] = pmap(
+            {
+                "text_replacements": pvector(
+                    [
+                        pmap({"pattern": "colour", "replacement": "color", "reason": "spelling"}),
+                    ]
+                ),
+            }
+        )
+        text = "The colour of the colour wheel"
+        result, stats = apply_text_replacements(text, config, pmap())
+        assert result == "The color of the color wheel"
+        assert stats["spelling"]["matches"] == 2
+
+    def test_empty_replacements_list(self) -> None:
+        config: Mapping[str, Any] = pmap()
+        text = "Content."
+        result, _stats = apply_text_replacements(text, config, pmap())
+        assert result == text

--- a/prepare-text/uv.lock
+++ b/prepare-text/uv.lock
@@ -172,6 +172,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -320,6 +329,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -345,6 +363,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
 name = "prepare-text"
 version = "0.1.0"
 source = { virtual = "." }
@@ -352,6 +388,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "google-genai" },
     { name = "markdown" },
+    { name = "pyrsistent" },
     { name = "pyyaml" },
     { name = "requests" },
 ]
@@ -359,6 +396,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "types-beautifulsoup4" },
     { name = "types-pyyaml" },
@@ -370,6 +408,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "markdown", specifier = ">=3.7" },
+    { name = "pyrsistent", specifier = ">=0.20.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.3" },
 ]
@@ -377,6 +416,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.20.0" },
+    { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.7.0" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0" },
     { name = "types-pyyaml", specifier = ">=6.0" },
@@ -501,6 +541,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388 },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879 },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "pyrsistent"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/3a/5031723c09068e9c8c2f0bc25c3a9245f2b1d1aea8396c787a408f2b95ca/pyrsistent-0.20.0.tar.gz", hash = "sha256:4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4", size = 103642 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/ee/ff2ed52032ac1ce2e7ba19e79bd5b05d152ebfb77956cf08fcd6e8d760ea/pyrsistent-0.20.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:09848306523a3aba463c4b49493a760e7a6ca52e4826aa100ee99d8d39b7ad1e", size = 83537 },
+    { url = "https://files.pythonhosted.org/packages/80/f1/338d0050b24c3132bcfc79b68c3a5f54bce3d213ecef74d37e988b971d8a/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a14798c3005ec892bbada26485c2eea3b54109cb2533713e355c806891f63c5e", size = 122615 },
+    { url = "https://files.pythonhosted.org/packages/07/3a/e56d6431b713518094fae6ff833a04a6f49ad0fbe25fb7c0dc7408e19d20/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b14decb628fac50db5e02ee5a35a9c0772d20277824cfe845c8a8b717c15daa3", size = 122335 },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/5f40a4d5e985a43b43f607250e766cdec28904682c3505eb0bd343a4b7db/pyrsistent-0.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e2c116cc804d9b09ce9814d17df5edf1df0c624aba3b43bc1ad90411487036d", size = 118510 },
+    { url = "https://files.pythonhosted.org/packages/1c/13/e6a22f40f5800af116c02c28e29f15c06aa41cb2036f6a64ab124647f28b/pyrsistent-0.20.0-cp312-cp312-win32.whl", hash = "sha256:e78d0c7c1e99a4a45c99143900ea0546025e41bb59ebc10182e947cf1ece9174", size = 60865 },
+    { url = "https://files.pythonhosted.org/packages/75/ef/2fa3b55023ec07c22682c957808f9a41836da4cd006b5f55ec76bf0fbfa6/pyrsistent-0.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:4021a7f963d88ccd15b523787d18ed5e5269ce57aa4037146a2377ff607ae87d", size = 63239 },
+    { url = "https://files.pythonhosted.org/packages/23/88/0acd180010aaed4987c85700b7cc17f9505f3edb4e5873e4dc67f613e338/pyrsistent-0.20.0-py3-none-any.whl", hash = "sha256:c55acc4733aad6560a7f5f818466631f07efc001fd023f34a6c203f8b6df0f0b", size = 58106 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,17 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["ALL"]
 preview = true
-ignore = ["D", "CPY", "PLR0914"]
+ignore = ["D", "CPY", "PLR0914", "LOG015", "COM812", "FBT003"]
+
+[tool.ruff.lint.per-file-ignores]
+"test_*.py" = ["S101", "PLR6301", "PLC2701", "ANN", "PLR2004"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 35
+
+[tool.ruff.lint.pylint]
+max-branches = 30
+max-statements = 120
 
 [tool.basedpyright]
 typeCheckingMode = "all"

--- a/rss/check-rss.py
+++ b/rss/check-rss.py
@@ -4,95 +4,127 @@ import os
 import pathlib
 import re
 import shutil
-from datetime import datetime, timedelta
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Final
 
-import feedparser
+import feedparser  # pyright: ignore[reportMissingTypeStubs]
 import msgspec
 import playwright.sync_api
 import requests
 import urllib3
 from bs4 import BeautifulSoup
 from dateutil import parser
+from feedparser import FeedParserDict  # pyright: ignore[reportMissingTypeStubs]
 from playwright.sync_api import sync_playwright
+from pyrsistent import PMap, PVector, freeze, pvector, thaw
 from requests.adapters import HTTPAdapter
 from trafilatura import bare_extraction, extract
 from urllib3.util.retry import Retry
 from waybackpy import WaybackMachineCDXServerAPI
+from waybackpy.cdx_snapshot import CDXSnapshot
 from waybackpy.exceptions import MaximumSaveRetriesExceeded, TooManyRequestsError
 
-local_scraper_url = "http://localhost:3002/fetch"
-bill_simmons_feed = "https://feeds.megaphone.fm/the-bill-simmons-podcast"
-# Create a Retry object with zero retries
-retry_strategy = Retry(
-    total=0,  # Total number of retries to allow
-    connect=0,  # Number of connection-related retries to allow
-    read=0,  # Number of read-related retries to allow
-    redirect=0,  # Number of redirection-related retries to allow
-    status=0,  # Number of retries to allow based on HTTP response status codes
+local_scraper_url: Final = "http://localhost:3002/fetch"
+bill_simmons_feed: Final = "https://feeds.megaphone.fm/the-bill-simmons-podcast"
+retry_strategy: Final = Retry(
+    total=0,
+    connect=0,
+    read=0,
+    redirect=0,
+    status=0,
 )
 
-# Create an HTTPAdapter with your retry strategy
-adapter = HTTPAdapter(max_retries=retry_strategy)
+adapter: Final = HTTPAdapter(max_retries=retry_strategy)
 
-enable_diagnosis = False
+enable_diagnosis: Final = False
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-output_folder = "../prepare-text/text-input-raw"
-feedsFile = "feeds.txt"
-wayback_feeds = [
+output_folder: Final = "../prepare-text/text-input-raw"
+feeds_file: Final = "feeds.txt"
+wayback_feeds: Final = (
     "https://www.nytimes.com/svc/collections/v1/publish/www.nytimes.com/column/ross-douthat/rss.xml",
     "https://www.nytimes.com/svc/collections/v1/publish/www.nytimes.com/column/ezra-klein/rss.xml",
     "https://www.nytimes.com/svc/collections/v1/publish/www.nytimes.com/column/thomas-l-friedman/rss.xml",
-]
+)
 
-feeds = [line.rstrip() for line in pathlib.Path(feedsFile).open(encoding="utf-8")]
+EXPECTED_TIMESTAMP_LENGTH: Final = 9
+
+with pathlib.Path(feeds_file).open(encoding="utf-8") as feeds_fh:
+    feeds: Final = tuple(line.rstrip() for line in feeds_fh)
 
 
-def send_gotify_notification(title, message, priority=6) -> None:
-    gotify_server = os.environ.get("GOTIFY_SERVER")
-    gotify_token = os.environ.get("GOTIFY_TOKEN")
+def send_gotify_notification(title: str, message: str, priority: int = 6) -> None:
+    gotify_server: Final = os.environ.get("GOTIFY_SERVER")
+    gotify_token: Final = os.environ.get("GOTIFY_TOKEN")
     if not gotify_server or not gotify_token:
         logging.warning("Gotify env vars not set; skipping notification.")
         return
-    gotify_url = f"{gotify_server}/message?token={gotify_token}"
-    data = {"title": title, "message": message, "priority": priority}
-    requests.post(gotify_url, data=data)
+    gotify_url: Final = f"{gotify_server}/message?token={gotify_token}"
+    # Mutable: requests.post requires dict
+    data: Final[dict[str, str | int]] = {"title": title, "message": message, "priority": priority}
+    _ = requests.post(gotify_url, data=data, timeout=30)
 
 
-def get_entry_link(entry):
-    link = getattr(entry, "link", None)
+def get_entry_link(entry: FeedParserDict) -> str:
+    link: Final = getattr(entry, "link", None)
     if link:
-        return link
-    for candidate in entry.get("links") or []:
-        href = candidate.get("href")
+        return str(link)  # pyright: ignore[reportAny]
+    for candidate in entry.get("links") or []:  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
+        href = candidate.get("href")  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
         if href:
-            return href
+            return str(href)  # pyright: ignore[reportUnknownArgumentType]
     return ""
 
 
-def fetch_and_process_html(url, final_request=False, headers=None, request_body=None):
+def build_metadata_block(feed_title: str, meta_title: str, original_url: str) -> str:
+    """Build the metadata block string for an RSS entry.
+
+    Returns
+    -------
+    - Newline-joined metadata block with META_ prefixed lines.
+
+    """
+    return "\n".join(
+        (
+            f"META_FROM: {feed_title}",
+            f"META_TITLE: {meta_title}",
+            f"META_SOURCE_URL: {original_url}",
+            "META_SOURCE_KIND: rss",
+            "META_INTAKE_TYPE: rss",
+        ),
+    )
+
+
+def fetch_and_process_html(
+    url: str,
+    final_request: bool = False,  # noqa: FBT001, FBT002
+    *,
+    request_body: Mapping[str, str] | None = None,
+) -> str | None:
     """Fetches HTML content from a given URL, processes it, and checks if it contains a specific phrase.
 
     Parameters
     ----------
     - url: The URL to fetch the HTML content from.
     - final_request: Boolean indicating if this is the last attempt to fetch the article.
-    - headers: Optional dictionary of headers to include in the request (GET or POST).
-    - request_body: Optional dictionary of data for making a POST request instead of a GET.
+    - request_body: Optional mapping of data for making a POST request instead of a GET.
 
     Returns
     -------
     - content_text: The processed HTML content as text, or None if the check fails.
 
     """
-    check_phrases = [
+    check_phrases: Final = (
         "has been an Opinion columnist",
         "From Beirut to Jerusalem",
         "joined Opinion in 2021",
-    ]
+    )
 
     logging.info("Fetching %s", url)
+
+    html_content: str | None = None
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
@@ -102,41 +134,39 @@ def fetch_and_process_html(url, final_request=False, headers=None, request_body=
         try:
             if request_body:
                 logging.info("Making GET request to %s with url query parameter", url)
-                page.goto(
+                _ = page.goto(
                     f"{url}?url={request_body['url']}",
                     wait_until="networkidle",
                     timeout=180000,
                 )
             else:
                 logging.info("Making GET request to %s", url)
-                page.goto(url, wait_until="networkidle", timeout=180000)
+                _ = page.goto(url, wait_until="networkidle", timeout=180000)
 
-            # Get rendered HTML content
             html_content = page.content()
 
-        except Exception as e:
-            logging.exception("Error occurred while fetching %s: %s", url, e)
+        except Exception:
+            logging.exception("Error occurred while fetching %s", url)
             html_content = None
 
         finally:
             browser.close()
 
-    html_content_parsed_for_title = bare_extraction(html_content, with_metadata=True)
-    webpage_text = extract(html_content, include_comments=False, favor_recall=True)
-    content_text = (
-        (html_content_parsed_for_title.as_dict().get("title") or "")
-        + ".\n"
-        + "\n"
-        + (webpage_text or "")
-    )
+    html_content_parsed_for_title: Final = bare_extraction(html_content, with_metadata=True)
+    webpage_text: Final = extract(html_content, include_comments=False, favor_recall=True)
+
+    title_text: str = ""
+    if html_content_parsed_for_title is not None and hasattr(html_content_parsed_for_title, "as_dict"):
+        title_text = str(html_content_parsed_for_title.as_dict().get("title") or "")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportAttributeAccessIssue]
+    content_text: Final = title_text + ".\n" + "\n" + (webpage_text or "")
 
     if all(phrase not in content_text for phrase in check_phrases):
         logging.error(
             "Kevin's or Wayback Machine's version of %s did not include the full article.",
             url,
         )
-        debug_message = "Error: Incomplete NYT article in Wayback Machine"
-        debug_output = f"{url}: {content_text}"
+        debug_message: Final = "Error: Incomplete NYT article in Wayback Machine"
+        debug_output: Final = f"{url}: {content_text}"
 
         if final_request:
             send_gotify_notification(debug_message, debug_output, priority=2)
@@ -145,44 +175,105 @@ def fetch_and_process_html(url, final_request=False, headers=None, request_body=
     return content_text
 
 
+def snapshot_to_dict(snapshot: CDXSnapshot) -> PMap[str, str]:
+    """Convert a CDXSnapshot to an immutable PMap.
+
+    Returns
+    -------
+    - PMap with snapshot attribute names as keys and string values.
+
+    """
+    result: dict[str, str] = {}  # Mutable: built incrementally then frozen
+    for attr in dir(snapshot):
+        if not attr.startswith("_") and not callable(
+            getattr(snapshot, attr),  # pyright: ignore[reportAny]
+        ):
+            value = getattr(snapshot, attr)  # pyright: ignore[reportAny]
+            if isinstance(value, datetime):
+                value = value.isoformat()
+            result[attr] = str(value)
+    return freeze(result)
+
+
+def filter_calendar_captures(
+    items: Sequence[Sequence[int]],
+    collections: Sequence[Sequence[int]],
+    year: int,
+    original_url: str,
+    collection_name: str,
+) -> tuple[str, ...]:
+    """Filter Wayback Machine calendar captures and return matching archive URLs.
+
+    Returns
+    -------
+    - Tuple of Wayback Machine archive URLs that match the collection name.
+
+    """
+    filtered: list[str] = []  # Mutable: accumulation then converted to tuple
+    for item in items:
+        timestamp, _status_code, collection_index = item
+        if collection_index < len(collections):
+            collection = collections[collection_index]
+            if collection_name in str(collection):
+                timestamp_str = str(timestamp)
+                if len(timestamp_str) == EXPECTED_TIMESTAMP_LENGTH:
+                    timestamp_str = timestamp_str.zfill(10)
+                formatted_timestamp = str(year) + timestamp_str
+                final_url = f"https://web.archive.org/web/{formatted_timestamp}/{original_url}"
+                filtered.append(final_url)
+    return tuple(filtered)
+
+
+def find_most_recent_guid_index(
+    entry_guids: Sequence[str],
+    most_recent_guid: str | None,
+) -> int | None:
+    """Return the index of the most recently processed GUID, or None if not found.
+
+    Returns
+    -------
+    - Index of most_recent_guid in entry_guids, or None if not found.
+
+    """
+    try:
+        return entry_guids.index(
+            most_recent_guid,
+        )
+    except ValueError:
+        return None
+
+
 for feed in feeds:
     try:
-        parsed_feed = feedparser.parse(feed)
+        parsed_feed = feedparser.parse(feed)  # pyright: ignore[reportUnknownMemberType]
 
-        # Prepare shared variables for file logging
-        now = datetime.now()
+        now = datetime.now(tz=UTC)
         date_string = now.strftime("%Y%m%d-%H%M%S")
         clean_feed_name = re.sub(r"[^A-Za-z0-9 ]+", "", feed)
         diagnosis_dir = "./diagnosis"
 
-        # Save the serializable feed data to a JSON file
         json_filename = f"{diagnosis_dir}/{clean_feed_name}-{date_string}-json.json"
         json_version_of_parsed_feed = msgspec.json.encode(parsed_feed)
 
-        # Sometimes The Money Illusion returns an old version of its feed for some reason. This prevents that from causing processing of old items.
-        feed_updated_raw = getattr(parsed_feed.feed, "updated", None)
+        # Sometimes The Money Illusion returns an old version of its feed for some reason.
+        # This prevents that from causing processing of old items.
+        feed_updated_raw = getattr(parsed_feed.feed, "updated", None)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
         if feed_updated_raw:
-            parsed_feed_updated_date = parser.parse(feed_updated_raw).replace(
+            parsed_feed_updated_date = parser.parse(str(feed_updated_raw)).replace(  # pyright: ignore[reportAny]
                 tzinfo=None,
             )
             max_timedelta_since_feed_last_updated = timedelta(days=7)
-            timedelta_since_feed_last_updated = now - parsed_feed_updated_date
-            if (
-                timedelta_since_feed_last_updated
-                > max_timedelta_since_feed_last_updated
-            ):
+            timedelta_since_feed_last_updated = now.replace(tzinfo=None) - parsed_feed_updated_date
+            if timedelta_since_feed_last_updated > max_timedelta_since_feed_last_updated:
                 error_threshold_timedelta_since_feed_last_updated = timedelta(days=30)
-                if (
-                    timedelta_since_feed_last_updated
-                    > error_threshold_timedelta_since_feed_last_updated
-                ):
+                if timedelta_since_feed_last_updated > error_threshold_timedelta_since_feed_last_updated:
                     logging.error(
                         "Error: %s-%s was more than 30 days old",
                         clean_feed_name,
                         date_string,
                     )
 
-                    pathlib.Path(json_filename).write_bytes(json_version_of_parsed_feed)
+                    _ = pathlib.Path(json_filename).write_bytes(json_version_of_parsed_feed)
                 else:
                     logging.info(
                         "%s-%s was more than 7 days old",
@@ -190,174 +281,153 @@ for feed in feeds:
                         date_string,
                     )
 
-                # Go to the next feed and stop processing this one
                 continue
 
         if enable_diagnosis:
-            pathlib.Path(json_filename).write_bytes(json_version_of_parsed_feed)
+            _ = pathlib.Path(json_filename).write_bytes(json_version_of_parsed_feed)
 
-        feed_title_raw = parsed_feed.feed.title
+        feed_title_raw: str = str(parsed_feed.feed.title)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportAttributeAccessIssue]
         feed_title_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", feed_title_raw)
-        feed_prefix_for_filename = (
-            feed_title_for_filename + "- " if feed_title_for_filename != "" else ""
-        )
+        feed_prefix_for_filename = feed_title_for_filename + "- " if feed_title_for_filename else ""
         guid_dir = "./feed-guids"
         guid_filename = f"{guid_dir}/{feed_title_for_filename}.txt"
         try:
-            most_recent_guid = pathlib.Path(guid_filename).read_text(encoding="utf-8")
-            # Copy current version of guids txt file
+            most_recent_guid: str | None = pathlib.Path(guid_filename).read_text(encoding="utf-8")
             if enable_diagnosis:
-                shutil.copy(
+                _ = shutil.copy(
                     guid_filename,
                     f"{diagnosis_dir}/{clean_feed_name}-{date_string}-guids-before.txt",
                 )
         except FileNotFoundError:
             most_recent_guid = None
-        parsed_feed_entry_guids = [
-            parsed_feed_entry.id for parsed_feed_entry in parsed_feed.entries
-        ]
+        parsed_feed_entry_guids: tuple[str, ...] = tuple(
+            str(parsed_feed_entry.id)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+            for parsed_feed_entry in parsed_feed.entries  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        )
         if most_recent_guid is None and feed == bill_simmons_feed:
-            if len(parsed_feed_entry_guids) >= 5:
+            if len(parsed_feed_entry_guids) >= 5:  # noqa: PLR2004
                 most_recent_guid = parsed_feed_entry_guids[4]
             elif len(parsed_feed_entry_guids) > 0:
                 most_recent_guid = parsed_feed_entry_guids[-1]
-        try:
-            most_recent_guid_index = parsed_feed_entry_guids.index(most_recent_guid)
-        except ValueError:
-            most_recent_guid_index = None
 
-        # Get list of RSS items that haven't been processed, process them from oldest to newest
-        feed_entries_before_most_recently_processed = parsed_feed.entries[
-            :most_recent_guid_index
-        ][::-1]
+        most_recent_guid_index = find_most_recent_guid_index(parsed_feed_entry_guids, most_recent_guid)
+
+        _raw_entries = tuple(parsed_feed.entries[:most_recent_guid_index][::-1])  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+        feed_entries_before_most_recently_processed = _raw_entries
 
         if len(feed_entries_before_most_recently_processed) > 0:
             logging.info(
-                f"Processing {len(feed_entries_before_most_recently_processed)} entries for {feed}",
+                "Processing %s entries for %s",
+                len(feed_entries_before_most_recently_processed),
+                feed,
             )
 
         for parsed_feed_entry in feed_entries_before_most_recently_processed:
-            raw_date = parser.parse(parsed_feed_entry.published)
+            raw_date = parser.parse(str(parsed_feed_entry.published))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
             date_stamp = raw_date.strftime("%Y%m%d-%H%M%S-%f")[0:15]
-            entry_title_raw = parsed_feed_entry.title
+            entry_title_raw: str = str(parsed_feed_entry.title)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
             entry_title_for_filename = re.sub(r"[^A-Za-z0-9 ]+", "", entry_title_raw)
             output_filename = f"{output_folder}/{date_stamp}-{feed_prefix_for_filename}{entry_title_for_filename}.txt"
             meta_title = entry_title_raw
             original_url = get_entry_link(parsed_feed_entry)
 
+            content_text: str | None
+            send_error_with_gotify: bool = False
+            two_most_recent_snapshots: PVector[CDXSnapshot] = pvector()
+
             if feed == bill_simmons_feed:
-                entry_description_raw = (
-                    parsed_feed_entry.get("summary")
-                    or parsed_feed_entry.get("description")
-                    or ""
+                entry_description_raw = str(
+                    parsed_feed_entry.get("summary")  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                    or parsed_feed_entry.get("description")  # pyright: ignore[reportUnknownMemberType]
+                    or "",
                 )
-                content_text = str(entry_description_raw)
+                content_text = entry_description_raw
             elif feed in wayback_feeds:
                 try:
                     send_error_with_gotify = False
                     max_timedelta_since_article_added_to_feed = timedelta(days=2)
-                    timedelta_since_article_added_to_feed = now - raw_date.replace(
+                    timedelta_since_article_added_to_feed = now.replace(tzinfo=None) - raw_date.replace(
                         tzinfo=None,
                     )
-                    if (
-                        timedelta_since_article_added_to_feed
-                        > max_timedelta_since_article_added_to_feed
-                    ):
+                    if timedelta_since_article_added_to_feed > max_timedelta_since_article_added_to_feed:
                         send_error_with_gotify = True
                     content_text = fetch_and_process_html(
                         url=local_scraper_url,
-                        headers={"Content-Type": "application/json"},
                         request_body={"url": original_url},
                     )
 
                     if content_text is None:
                         user_agent = "Mozilla/5.0 (Windows NT 5.1; rv:40.0) Gecko/20100101 Firefox/40.0"
                         cdx_api = WaybackMachineCDXServerAPI(original_url, user_agent)
-                        snapshots = list(cdx_api.snapshots())
-                        sorted_snapshots = sorted(
-                            snapshots,
-                            key=lambda x: x.datetime_timestamp,
-                            reverse=True,
+                        snapshots_gen = list(cdx_api.snapshots())
+                        sorted_snapshots = tuple(
+                            sorted(
+                                snapshots_gen,
+                                key=lambda x: x.datetime_timestamp,
+                                reverse=True,
+                            ),
                         )
-                        two_most_recent_snapshots = sorted_snapshots[:2]
+                        two_most_recent_snapshots = pvector(sorted_snapshots[:2])
 
                         if send_error_with_gotify or enable_diagnosis:
-                            # Function to convert a CDXSnapshot object to a dictionary dynamically
-                            def snapshot_to_dict(snapshot):
-                                result = {}
-                                for attr in dir(snapshot):
-                                    if not attr.startswith("_") and not callable(
-                                        getattr(snapshot, attr),
-                                    ):
-                                        value = getattr(snapshot, attr)
-                                        if isinstance(value, datetime):
-                                            value = value.isoformat()
-                                        result[attr] = value
-                                return result
-
-                            snapshots_list = [
-                                snapshot_to_dict(snapshot) for snapshot in snapshots
-                            ]
-                            snapshots_json_filename = f"{diagnosis_dir}/{clean_feed_name}-{date_string}-snapshots-json.json"
+                            snapshots_pv = pvector(snapshot_to_dict(snapshot) for snapshot in snapshots_gen)
+                            snapshots_json_filename = (
+                                f"{diagnosis_dir}/{clean_feed_name}-{date_string}-snapshots-json.json"
+                            )
+                            # Mutable: json.dump requires list/dict
+                            snapshots_list_for_json = thaw(snapshots_pv)
                             with pathlib.Path(snapshots_json_filename).open(
                                 "w",
                                 encoding="utf-8",
                             ) as json_file:
-                                json.dump(snapshots_list, json_file, indent=2)
+                                json.dump(snapshots_list_for_json, json_file, indent=2)
 
                         content_text = None
 
-                        this_year = datetime.now().year
-                        calendar_captures_api_url_this_year = f"https://web.archive.org/__wb/calendarcaptures/2?url={original_url}&date={this_year}"
+                        this_year = datetime.now(tz=UTC).year
+                        calendar_captures_api_url_this_year = (
+                            f"https://web.archive.org/__wb/calendarcaptures/2?url={original_url}&date={this_year}"
+                        )
                         this_year_response = requests.get(
                             calendar_captures_api_url_this_year,
+                            timeout=30,
                         )
-                        this_year_data = this_year_response.json()
+                        this_year_data: PMap[str, PVector[PVector[int]]] = freeze(this_year_response.json())  # pyright: ignore[reportAny, reportUnknownVariableType]
 
                         last_year = this_year - 1
-                        calendar_captures_api_url_last_year = f"https://web.archive.org/__wb/calendarcaptures/2?url={original_url}&date={last_year}"
+                        calendar_captures_api_url_last_year = (
+                            f"https://web.archive.org/__wb/calendarcaptures/2?url={original_url}&date={last_year}"
+                        )
                         last_year_response = requests.get(
                             calendar_captures_api_url_last_year,
+                            timeout=30,
                         )
-                        last_year_data = last_year_response.json()
+                        last_year_data: PMap[str, PVector[PVector[int]]] = freeze(last_year_response.json())  # pyright: ignore[reportAny, reportUnknownVariableType]
 
-                        # Collection name we are interested in
                         collection_name = "global.nytimes.com"
 
-                        # Extract the collections and items
-                        this_year_collections = this_year_data.get("colls") or []
-                        this_year_items = this_year_data.get("items") or []
+                        # Thaw collections/items for filter_calendar_captures which accepts Sequence
+                        this_year_collections = thaw(this_year_data.get("colls", pvector()))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                        this_year_items = thaw(this_year_data.get("items", pvector()))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
 
-                        # Extract the collections and items
-                        last_year_collections = last_year_data.get("colls") or []
-                        last_year_items = last_year_data.get("items") or []
+                        last_year_collections = thaw(last_year_data.get("colls", pvector()))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                        last_year_items = thaw(last_year_data.get("items", pvector()))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
 
-                        # Filter items by the "global.nytimes.com" collection
-                        filtered_captures = []
-
-                        for item in this_year_items:
-                            timestamp, status_code, collection_index = item
-                            if collection_index < len(this_year_collections):
-                                collection = this_year_collections[collection_index]
-                                if collection_name in collection:
-                                    timestamp_str = str(timestamp)
-                                    if len(timestamp_str) == 9:
-                                        timestamp_str = timestamp_str.zfill(10)
-                                    formatted_timestamp = str(this_year) + timestamp_str
-                                    final_url = f"https://web.archive.org/web/{formatted_timestamp}/{original_url}"
-                                    filtered_captures.append(final_url)
-
-                        for item in last_year_items:
-                            timestamp, status_code, collection_index = item
-                            if collection_index < len(last_year_collections):
-                                collection = last_year_collections[collection_index]
-                                if collection_name in collection:
-                                    timestamp_str = str(timestamp)
-                                    if len(timestamp_str) == 9:
-                                        timestamp_str = timestamp_str.zfill(10)
-                                    formatted_timestamp = str(this_year) + timestamp_str
-                                    final_url = f"https://web.archive.org/web/{formatted_timestamp}/{original_url}"
-                                    filtered_captures.append(final_url)
+                        this_year_captures = filter_calendar_captures(
+                            this_year_items,
+                            this_year_collections,
+                            this_year,
+                            original_url,
+                            collection_name,
+                        )
+                        last_year_captures = filter_calendar_captures(
+                            last_year_items,
+                            last_year_collections,
+                            this_year,
+                            original_url,
+                            collection_name,
+                        )
+                        filtered_captures = this_year_captures + last_year_captures
 
                         for filtered_capture in filtered_captures:
                             content_text = fetch_and_process_html(url=filtered_capture)
@@ -372,19 +442,8 @@ for feed in feeds:
                             if content_text is not None:
                                 break
 
-                    # Temporary comment out of save API call since Wayback isn't working
-                    #
-                    # if content_text is None:
-                    #     save_api = WaybackMachineSaveAPI(original_url, user_agent)
-                    #     save_api.save()
-                    #     new_archive_url = save_api.archive_url
-
-                    #     content_text = fetch_and_process_html(
-                    #         url=new_archive_url,
-                    #         final_request=send_error_with_gotify,
-                    #     )
-
-                    # If we failed to get the real article, stop processing this feed altogether so the article doesn't get skipped next time.
+                    # If we failed to get the real article, stop processing this feed
+                    # altogether so the article doesn't get skipped next time.
                     if content_text is None:
                         break
                 except (
@@ -396,11 +455,11 @@ for feed in feeds:
                     urllib3.exceptions.MaxRetryError,
                     TooManyRequestsError,
                     MaximumSaveRetriesExceeded,
-                ) as e:
-                    logging.exception("Error occurred: %s", e)
+                ):
+                    logging.exception("Error occurred")
                     logging.info("%s URL caused the issue.", original_url)
                     debug_message = "RSS URL catastrophic error"
-                    debug_output = f"{original_url}: {e}"
+                    debug_output = f"{original_url}"
 
                     if send_error_with_gotify:
                         send_gotify_notification(
@@ -410,34 +469,26 @@ for feed in feeds:
                         )
                     break
             else:
-                soup = BeautifulSoup(parsed_feed_entry.content[0].value, "html.parser")
+                soup = BeautifulSoup(
+                    str(parsed_feed_entry.content[0].value),  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                    "html.parser",
+                )
                 content_text = soup.get_text()
-            output_file = pathlib.Path(output_filename).open("w", encoding="utf-8")
-            metadata_block = "\n".join(
-                [
-                    f"META_FROM: {feed_title_raw}",
-                    f"META_TITLE: {meta_title}",
-                    f"META_SOURCE_URL: {original_url}",
-                    "META_SOURCE_KIND: rss",
-                    "META_INTAKE_TYPE: rss",
-                ],
-            )
+            metadata_block = build_metadata_block(feed_title_raw, meta_title, original_url)
             logging.info("Writing raw metadata and text to text input")
-            output_file.write(metadata_block + "\n\n" + content_text)
-            output_file.close()
-            guidDirExists = pathlib.Path(guid_dir).exists()
-            if not guidDirExists:
+            _ = pathlib.Path(output_filename).write_text(metadata_block + "\n\n" + content_text, encoding="utf-8")
+            if not pathlib.Path(guid_dir).exists():
                 pathlib.Path(guid_dir).mkdir(parents=True)
-            guid_output_file = pathlib.Path(guid_filename).open("w", encoding="utf-8")
-            guid_output_file.write(parsed_feed_entry.id)
-            guid_output_file.close()
-            # Copy new version of guids txt file
-            date_string = datetime.now().strftime("%Y%m%d-%H%M%S")
+            _ = pathlib.Path(guid_filename).write_text(
+                str(parsed_feed_entry.id),  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                encoding="utf-8",
+            )
+            date_string = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
             if enable_diagnosis:
-                shutil.copy(
+                _ = shutil.copy(
                     guid_filename,
                     f"{diagnosis_dir}/{clean_feed_name}-{date_string}-guids-after.txt",
                 )
-    except Exception as e:
-        logging.exception("Error occurred: %s", e)
+    except Exception:
+        logging.exception("Error occurred")
         logging.info("%s URL caused the issue.", feed)

--- a/rss/pyproject.toml
+++ b/rss/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "feedparser>=6.0.11",
     "msgspec>=0.19.0",
     "google-genai>=1.0.0",
+    "pyrsistent>=0.20.0",
     "playwright>=1.49.1",
     "python-dateutil>=2.9.0.post0",
     "trafilatura>=2.0.0",
@@ -18,6 +19,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "basedpyright>=1.20.0",
+    "pytest>=8.0",
     "ruff>=0.7.0",
     "types-beautifulsoup4>=4.12.0",
     "types-python-dateutil>=2.9.0",

--- a/rss/test_check_rss.py
+++ b/rss/test_check_rss.py
@@ -29,10 +29,20 @@ def _load_check_rss() -> ModuleType:
     assert spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
 
+    # Create a dummy feeds.txt if it doesn't exist (e.g. in CI where *.txt is gitignored).
+    feeds_path = Path(__file__).parent / "feeds.txt"
+    created_feeds = False
+    if not feeds_path.exists():
+        feeds_path.write_text("https://example.com/feed.xml\n", encoding="utf-8")
+        created_feeds = True
+
     # Mock feedparser.parse so the module-level for-loop does not make network requests.
-    # The feeds tuple will still be populated from the real feeds.txt.
-    with patch("feedparser.parse", return_value=MagicMock(feed=MagicMock(updated=None), entries=[])):
-        spec.loader.exec_module(mod)
+    try:
+        with patch("feedparser.parse", return_value=MagicMock(feed=MagicMock(updated=None), entries=[])):
+            spec.loader.exec_module(mod)
+    finally:
+        if created_feeds:
+            feeds_path.unlink(missing_ok=True)
 
     sys.modules["check_rss"] = mod
     return mod

--- a/rss/test_check_rss.py
+++ b/rss/test_check_rss.py
@@ -1,0 +1,299 @@
+# pyright: reportExplicitAny=false, reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportUnknownLambdaType=false
+"""Tests for pure/testable functions in check-rss.py."""
+
+import importlib.util
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pyrsistent import PMap
+
+
+def _load_check_rss() -> ModuleType:
+    """Load check-rss.py as a module, mocking heavy I/O to prevent network calls on import.
+
+    Returns
+    -------
+    - The loaded check-rss module.
+
+    """
+    # Remove previously cached version
+    sys.modules.pop("check_rss", None)
+
+    module_path = Path(__file__).parent / "check-rss.py"
+    spec = importlib.util.spec_from_file_location("check_rss", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+
+    # Mock feedparser.parse so the module-level for-loop does not make network requests.
+    # The feeds tuple will still be populated from the real feeds.txt.
+    with patch("feedparser.parse", return_value=MagicMock(feed=MagicMock(updated=None), entries=[])):
+        spec.loader.exec_module(mod)
+
+    sys.modules["check_rss"] = mod
+    return mod
+
+
+@pytest.fixture(scope="session")
+def mod():
+    """Load the module once per test session.
+
+    Returns
+    -------
+    - The loaded check-rss module.
+
+    """
+    return _load_check_rss()
+
+
+# ===========================================================================
+# get_entry_link
+# ===========================================================================
+class TestGetEntryLink:
+    def test_returns_link_attribute(self, mod):
+        entry = SimpleNamespace(link="https://example.com/article")
+        assert mod.get_entry_link(entry) == "https://example.com/article"
+
+    def test_returns_href_from_links_when_no_link(self, mod):
+        entry = SimpleNamespace(link=None)
+        entry.get = lambda key: [{"href": "https://fallback.com/page"}] if key == "links" else None
+        assert mod.get_entry_link(entry) == "https://fallback.com/page"
+
+    def test_returns_empty_string_when_no_link_or_links(self, mod):
+        entry = SimpleNamespace(link=None)
+        entry.get = lambda _key: None
+        result = mod.get_entry_link(entry)
+        assert result == ""  # noqa: PLC1901
+
+    def test_skips_empty_hrefs_in_links(self, mod):
+        entry = SimpleNamespace(link=None)
+        entry.get = lambda key: [{"href": ""}, {"href": "https://second.com"}] if key == "links" else None
+        assert mod.get_entry_link(entry) == "https://second.com"
+
+    def test_returns_empty_when_links_have_no_href(self, mod):
+        entry = SimpleNamespace(link=None)
+        entry.get = lambda key: [{"type": "text/html"}] if key == "links" else None
+        result = mod.get_entry_link(entry)
+        assert result == ""  # noqa: PLC1901
+
+
+# ===========================================================================
+# build_metadata_block
+# ===========================================================================
+class TestBuildMetadataBlock:
+    def test_basic_metadata(self, mod):
+        result = mod.build_metadata_block("My Feed", "Article Title", "https://example.com/article")
+        assert "META_FROM: My Feed" in result
+        assert "META_TITLE: Article Title" in result
+        assert "META_SOURCE_URL: https://example.com/article" in result
+        assert "META_SOURCE_KIND: rss" in result
+        assert "META_INTAKE_TYPE: rss" in result
+
+    def test_metadata_lines_are_newline_separated(self, mod):
+        result = mod.build_metadata_block("Feed", "Title", "https://url.com")
+        lines = result.split("\n")
+        assert len(lines) == 5
+
+    def test_empty_strings(self, mod):
+        result = mod.build_metadata_block("", "", "")
+        assert "META_FROM: " in result
+        assert "META_TITLE: " in result
+        assert "META_SOURCE_URL: " in result
+
+
+# ===========================================================================
+# snapshot_to_dict
+# ===========================================================================
+class TestSnapshotToDict:
+    def test_converts_snapshot_attributes_to_pmap(self, mod):
+        snapshot = MagicMock()
+        snapshot.archive_url = "https://web.archive.org/web/123/https://example.com"
+        snapshot.datetime_timestamp = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+        snapshot.original = "https://example.com"
+        snapshot.statuscode = "200"
+
+        result = mod.snapshot_to_dict(snapshot)
+
+        assert isinstance(result, PMap)
+        # datetime values should be ISO-formatted strings
+        assert "2024-01-15" in result["datetime_timestamp"]
+
+    def test_returns_immutable_pmap(self, mod):
+        snapshot = MagicMock()
+        snapshot.url = "https://example.com"
+        result = mod.snapshot_to_dict(snapshot)
+        assert isinstance(result, PMap)
+
+
+# ===========================================================================
+# filter_calendar_captures
+# ===========================================================================
+class TestFilterCalendarCaptures:
+    def test_filters_matching_collection(self, mod):
+        items = [[1234567890, 200, 0]]
+        collections = [["global.nytimes.com"]]
+        result = mod.filter_calendar_captures(
+            items, collections, 2024, "https://nytimes.com/article", "global.nytimes.com"
+        )
+        assert len(result) == 1
+        assert "web.archive.org" in result[0]
+        assert "https://nytimes.com/article" in result[0]
+
+    def test_skips_non_matching_collection(self, mod):
+        items = [[1234567890, 200, 0]]
+        collections = [["other.collection"]]
+        result = mod.filter_calendar_captures(
+            items, collections, 2024, "https://nytimes.com/article", "global.nytimes.com"
+        )
+        assert len(result) == 0
+
+    def test_skips_out_of_range_collection_index(self, mod):
+        items = [[1234567890, 200, 5]]  # index 5, but only 1 collection
+        collections = [["global.nytimes.com"]]
+        result = mod.filter_calendar_captures(
+            items, collections, 2024, "https://nytimes.com/article", "global.nytimes.com"
+        )
+        assert len(result) == 0
+
+    def test_pads_9_digit_timestamps(self, mod):
+        # 9-digit timestamp should be zero-padded to 10 digits
+        items = [[123456789, 200, 0]]
+        collections = [["global.nytimes.com"]]
+        result = mod.filter_calendar_captures(
+            items, collections, 2024, "https://nytimes.com/article", "global.nytimes.com"
+        )
+        assert len(result) == 1
+        # Should contain the year + zero-padded timestamp
+        assert "20240123456789" in result[0]
+
+    def test_does_not_pad_non_9_digit_timestamps(self, mod):
+        items = [[12345678901, 200, 0]]  # 11 digits, should not be padded
+        collections = [["global.nytimes.com"]]
+        result = mod.filter_calendar_captures(
+            items, collections, 2024, "https://nytimes.com/article", "global.nytimes.com"
+        )
+        assert len(result) == 1
+        assert "202412345678901" in result[0]
+
+    def test_multiple_items(self, mod):
+        items = [
+            [1111111111, 200, 0],
+            [2222222222, 200, 1],
+            [3333333333, 200, 0],
+        ]
+        collections = [["global.nytimes.com"], ["other.collection"]]
+        result = mod.filter_calendar_captures(
+            items, collections, 2024, "https://nytimes.com/article", "global.nytimes.com"
+        )
+        # Only items with collection index 0 match
+        assert len(result) == 2
+
+    def test_returns_tuple(self, mod):
+        result = mod.filter_calendar_captures([], [], 2024, "https://example.com", "nytimes")
+        assert isinstance(result, tuple)
+
+    def test_empty_items(self, mod):
+        result = mod.filter_calendar_captures([], [["global.nytimes.com"]], 2024, "https://example.com", "nytimes")
+        assert result == ()
+
+
+# ===========================================================================
+# find_most_recent_guid_index
+# ===========================================================================
+class TestFindMostRecentGuidIndex:
+    def test_returns_index_when_found(self, mod):
+        guids = ("a", "b", "c", "d")
+        assert mod.find_most_recent_guid_index(guids, "c") == 2
+
+    def test_returns_none_when_not_found(self, mod):
+        guids = ("a", "b", "c")
+        assert mod.find_most_recent_guid_index(guids, "z") is None
+
+    def test_returns_none_when_guid_is_none(self, mod):
+        guids = ("a", "b", "c")
+        assert mod.find_most_recent_guid_index(guids, None) is None
+
+    def test_returns_zero_for_first_element(self, mod):
+        guids = ("x", "y", "z")
+        assert mod.find_most_recent_guid_index(guids, "x") == 0
+
+    def test_empty_guids(self, mod):
+        assert mod.find_most_recent_guid_index((), "a") is None
+
+    def test_works_with_list(self, mod):
+        guids = ["a", "b", "c"]
+        assert mod.find_most_recent_guid_index(guids, "b") == 1
+
+
+# ===========================================================================
+# send_gotify_notification
+# ===========================================================================
+class TestSendGotifyNotification:
+    def test_sends_notification_with_correct_data(self, mod, monkeypatch):
+        monkeypatch.setenv("GOTIFY_SERVER", "https://gotify.example.com")
+        monkeypatch.setenv("GOTIFY_TOKEN", "test-token-123")
+
+        mock_post = MagicMock()
+        monkeypatch.setattr(mod.requests, "post", mock_post)
+
+        mod.send_gotify_notification("Test Title", "Test Message", priority=8)
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "https://gotify.example.com/message?token=test-token-123"
+        assert call_args[1]["data"]["title"] == "Test Title"
+        assert call_args[1]["data"]["message"] == "Test Message"
+        assert call_args[1]["data"]["priority"] == 8
+        assert call_args[1]["timeout"] == 30
+
+    def test_default_priority_is_six(self, mod, monkeypatch):
+        monkeypatch.setenv("GOTIFY_SERVER", "https://gotify.example.com")
+        monkeypatch.setenv("GOTIFY_TOKEN", "test-token")
+
+        mock_post = MagicMock()
+        monkeypatch.setattr(mod.requests, "post", mock_post)
+
+        mod.send_gotify_notification("Title", "Message")
+
+        call_args = mock_post.call_args
+        assert call_args[1]["data"]["priority"] == 6
+
+    def test_skips_when_gotify_server_not_set(self, mod, monkeypatch):
+        monkeypatch.delenv("GOTIFY_SERVER", raising=False)
+        monkeypatch.delenv("GOTIFY_TOKEN", raising=False)
+
+        mock_post = MagicMock()
+        monkeypatch.setattr(mod.requests, "post", mock_post)
+
+        mod.send_gotify_notification("Title", "Message")
+
+        mock_post.assert_not_called()
+
+    def test_skips_when_gotify_token_not_set(self, mod, monkeypatch):
+        monkeypatch.setenv("GOTIFY_SERVER", "https://gotify.example.com")
+        monkeypatch.delenv("GOTIFY_TOKEN", raising=False)
+
+        mock_post = MagicMock()
+        monkeypatch.setattr(mod.requests, "post", mock_post)
+
+        mod.send_gotify_notification("Title", "Message")
+
+        mock_post.assert_not_called()
+
+
+# ===========================================================================
+# Module-level constants
+# ===========================================================================
+class TestModuleConstants:
+    def test_wayback_feeds_is_tuple(self, mod):
+        assert isinstance(mod.wayback_feeds, tuple)
+
+    def test_feeds_is_tuple(self, mod):
+        assert isinstance(mod.feeds, tuple)
+
+    def test_wayback_feeds_contains_nyt_urls(self, mod):
+        assert all("nytimes.com" in url for url in mod.wayback_feeds)

--- a/rss/uv.lock
+++ b/rss/uv.lock
@@ -417,6 +417,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
 name = "justext"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -527,6 +536,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366 },
+]
+
+[[package]]
 name = "playwright"
 version = "1.49.1"
 source = { registry = "https://pypi.org/simple" }
@@ -542,6 +560,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/52/95efac704bf36b770a2522d88a6dee298042845d10bfb35f7ca0fcc36d91/playwright-1.49.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd9bc8dab37aa25198a01f555f0a2e2c3813fe200fef018ac34dfe86b34994b9", size = 43744353 },
     { url = "https://files.pythonhosted.org/packages/f9/97/a3fccc9aaa6da83890772e9980703b0ea6b1e1ad42042fb50df3aef6c641/playwright-1.49.1-py3-none-win32.whl", hash = "sha256:43b304be67f096058e587dac453ece550eff87b8fbed28de30f4f022cc1745bb", size = 34060663 },
     { url = "https://files.pythonhosted.org/packages/71/a9/bd88ac0bd498c91aab3aba2e393d1fa59f72a7243e9265ccbf4861ca4f64/playwright-1.49.1-py3-none-win_amd64.whl", hash = "sha256:47b23cb346283278f5b4d1e1990bcb6d6302f80c0aa0ca93dd0601a1400191df", size = 34060667 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
 ]
 
 [[package]]
@@ -644,6 +671,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "pyrsistent"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/3a/5031723c09068e9c8c2f0bc25c3a9245f2b1d1aea8396c787a408f2b95ca/pyrsistent-0.20.0.tar.gz", hash = "sha256:4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4", size = 103642 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/ee/ff2ed52032ac1ce2e7ba19e79bd5b05d152ebfb77956cf08fcd6e8d760ea/pyrsistent-0.20.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:09848306523a3aba463c4b49493a760e7a6ca52e4826aa100ee99d8d39b7ad1e", size = 83537 },
+    { url = "https://files.pythonhosted.org/packages/80/f1/338d0050b24c3132bcfc79b68c3a5f54bce3d213ecef74d37e988b971d8a/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a14798c3005ec892bbada26485c2eea3b54109cb2533713e355c806891f63c5e", size = 122615 },
+    { url = "https://files.pythonhosted.org/packages/07/3a/e56d6431b713518094fae6ff833a04a6f49ad0fbe25fb7c0dc7408e19d20/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b14decb628fac50db5e02ee5a35a9c0772d20277824cfe845c8a8b717c15daa3", size = 122335 },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/5f40a4d5e985a43b43f607250e766cdec28904682c3505eb0bd343a4b7db/pyrsistent-0.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e2c116cc804d9b09ce9814d17df5edf1df0c624aba3b43bc1ad90411487036d", size = 118510 },
+    { url = "https://files.pythonhosted.org/packages/1c/13/e6a22f40f5800af116c02c28e29f15c06aa41cb2036f6a64ab124647f28b/pyrsistent-0.20.0-cp312-cp312-win32.whl", hash = "sha256:e78d0c7c1e99a4a45c99143900ea0546025e41bb59ebc10182e947cf1ece9174", size = 60865 },
+    { url = "https://files.pythonhosted.org/packages/75/ef/2fa3b55023ec07c22682c957808f9a41836da4cd006b5f55ec76bf0fbfa6/pyrsistent-0.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:4021a7f963d88ccd15b523787d18ed5e5269ce57aa4037146a2377ff607ae87d", size = 63239 },
+    { url = "https://files.pythonhosted.org/packages/23/88/0acd180010aaed4987c85700b7cc17f9505f3edb4e5873e4dc67f613e338/pyrsistent-0.20.0-py3-none-any.whl", hash = "sha256:c55acc4733aad6560a7f5f818466631f07efc001fd023f34a6c203f8b6df0f0b", size = 58106 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -739,6 +806,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "msgspec" },
     { name = "playwright" },
+    { name = "pyrsistent" },
     { name = "python-dateutil" },
     { name = "trafilatura" },
     { name = "waybackpy" },
@@ -747,6 +815,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "types-beautifulsoup4" },
     { name = "types-python-dateutil" },
@@ -760,6 +829,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
     { name = "playwright", specifier = ">=1.49.1" },
+    { name = "pyrsistent", specifier = ">=0.20.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "waybackpy", specifier = ">=3.0.6" },
@@ -768,6 +838,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.20.0" },
+    { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.7.0" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0" },
     { name = "types-python-dateutil", specifier = ">=2.9.0" },

--- a/text-to-speech/pyproject.toml
+++ b/text-to-speech/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "google-cloud-texttospeech>=2.23.0",
     "mutagen>=1.47.0",
     "google-genai>=1.0.0",
+    "pyrsistent>=0.20.0",
     "pydub>=0.25.1",
     "requests>=2.32.3",
 ]
@@ -16,6 +17,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "basedpyright>=1.20.0",
+    "pytest>=8.0",
     "ruff>=0.7.0",
     "types-beautifulsoup4>=4.12.0",
     "types-requests>=2.32.0",

--- a/text-to-speech/test_text_to_speech.py
+++ b/text-to-speech/test_text_to_speech.py
@@ -1,0 +1,247 @@
+# pyright: reportExplicitAny=false, reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+from typing import Final
+
+import pytest
+from pyrsistent import PMap, pmap
+
+from text_to_speech import (
+    DescriptionParams,
+    _build_output_filename,
+    _build_title_for_tag,
+    build_description,
+    split_metadata,
+    to_base36,
+)
+
+
+class TestSplitMetadata:
+    def test_no_metadata_returns_empty_pmap_and_full_text(self):
+        raw: Final = "Just some plain text\nwith multiple lines"
+        metadata, content = split_metadata(raw)
+        assert metadata == pmap({})
+        assert content == raw
+
+    def test_single_meta_field(self):
+        raw: Final = "META_FROM: John Doe\n\nBody text here"
+        metadata, content = split_metadata(raw)
+        assert metadata == pmap({"from": "John Doe"})
+        assert content == "Body text here"
+
+    def test_multiple_meta_fields(self):
+        raw: Final = (
+            "META_FROM: Alice\n"
+            "META_TITLE: My Article\n"
+            "META_SOURCE_URL: https://example.com\n"
+            "META_SOURCE_KIND: beehiiv\n"
+            "\n"
+            "Article body"
+        )
+        metadata, content = split_metadata(raw)
+        assert metadata["from"] == "Alice"
+        assert metadata["title"] == "My Article"
+        assert metadata["source_url"] == "https://example.com"
+        assert metadata["source_kind"] == "beehiiv"
+        assert content == "Article body"
+
+    def test_continuation_lines(self):
+        raw: Final = "META_TITLE: A Very Long Title\n  That Continues Here\n\nContent"
+        metadata, content = split_metadata(raw)
+        assert metadata["title"] == "A Very Long Title That Continues Here"
+        assert content == "Content"
+
+    def test_tab_continuation_lines(self):
+        raw: Final = "META_TITLE: Start\n\tContinued\n\nBody"
+        metadata, content = split_metadata(raw)
+        assert metadata["title"] == "Start Continued"
+        assert content == "Body"
+
+    def test_empty_body(self):
+        raw: Final = "META_TITLE: Only Meta\n"
+        metadata, content = split_metadata(raw)
+        assert metadata["title"] == "Only Meta"
+        assert not content
+
+    def test_meta_without_colon_stops_parsing(self):
+        raw: Final = "META_BROKEN\nBody text"
+        metadata, content = split_metadata(raw)
+        assert metadata == pmap({})
+        assert content == "META_BROKEN\nBody text"
+
+    def test_returns_pmap_type(self):
+        raw: Final = "META_FROM: Test\n\nBody"
+        metadata, _ = split_metadata(raw)
+        assert isinstance(metadata, PMap)
+
+    def test_meta_value_whitespace_stripped(self):
+        raw: Final = "META_TITLE:   spaces around   \n\nContent"
+        metadata, content = split_metadata(raw)
+        assert metadata["title"] == "spaces around"
+        assert content == "Content"
+
+    def test_non_meta_line_stops_parsing(self):
+        raw: Final = "META_FROM: Alice\nNot a meta line\nmore text"
+        metadata, content = split_metadata(raw)
+        assert metadata["from"] == "Alice"
+        assert content == "Not a meta line\nmore text"
+
+
+class TestBuildDescription:
+    def test_minimal_params(self):
+        params: Final = DescriptionParams(summary="A summary", title="Title", source_url="", source_kind="")
+        result: Final = build_description(params)
+        assert result == "A summary<br/><br/>Title: Title"
+
+    def test_no_summary_shows_unavailable(self):
+        params: Final = DescriptionParams(summary="", title="Title", source_url="", source_kind="")
+        result: Final = build_description(params)
+        assert "Summary unavailable." in result
+
+    def test_no_title_shows_untitled(self):
+        params: Final = DescriptionParams(summary="A summary", title="", source_url="", source_kind="")
+        result: Final = build_description(params)
+        assert "Title: Untitled" in result
+
+    def test_with_source_url(self):
+        params: Final = DescriptionParams(
+            summary="Sum", title="T", source_url="https://example.com", source_kind="substack"
+        )
+        result: Final = build_description(params)
+        assert '<a href="https://example.com">https://example.com</a>' in result
+
+    def test_beehiiv_source_uses_name(self):
+        params: Final = DescriptionParams(
+            summary="Sum",
+            title="T",
+            source_url="https://example.com",
+            source_kind="beehiiv",
+            source_name="My Newsletter",
+        )
+        result: Final = build_description(params)
+        assert '<a href="https://example.com">My Newsletter</a>' in result
+
+    def test_beehiiv_without_name_uses_url(self):
+        params: Final = DescriptionParams(
+            summary="Sum", title="T", source_url="https://example.com", source_kind="beehiiv", source_name=""
+        )
+        result: Final = build_description(params)
+        assert '<a href="https://example.com">https://example.com</a>' in result
+
+    def test_intake_type_email(self):
+        params: Final = DescriptionParams(summary="Sum", title="T", source_url="", source_kind="", intake_type="email")
+        result: Final = build_description(params)
+        assert "Via: Email" in result
+
+    def test_intake_type_rss(self):
+        params: Final = DescriptionParams(summary="Sum", title="T", source_url="", source_kind="", intake_type="rss")
+        result: Final = build_description(params)
+        assert "Via: RSS" in result
+
+    def test_intake_type_unknown_passes_through(self):
+        params: Final = DescriptionParams(
+            summary="Sum", title="T", source_url="", source_kind="", intake_type="carrier_pigeon"
+        )
+        result: Final = build_description(params)
+        assert "Via: carrier_pigeon" in result
+
+    def test_all_parts_joined_with_br(self):
+        params: Final = DescriptionParams(
+            summary="Sum",
+            title="T",
+            source_url="https://example.com",
+            source_kind="substack",
+            intake_type="email",
+        )
+        result: Final = build_description(params)
+        parts = result.split("<br/><br/>")
+        assert len(parts) == 4
+        assert parts[0] == "Sum"
+        assert parts[1] == "Title: T"
+        assert parts[2] == "Via: Email"
+        assert "Source:" in parts[3]
+
+
+class TestToBase36:
+    def test_zero(self):
+        assert to_base36(0) == "0"
+
+    def test_small_numbers(self):
+        assert to_base36(1) == "1"
+        assert to_base36(10) == "a"
+        assert to_base36(35) == "z"
+
+    def test_thirty_six(self):
+        assert to_base36(36) == "10"
+
+    def test_large_number(self):
+        assert to_base36(1000) == "rs"
+
+    def test_unix_timestamp_range(self):
+        result: Final = to_base36(1700000000)
+        assert len(result) == 6
+        assert all(c in "0123456789abcdefghijklmnopqrstuvwxyz" for c in result)
+
+    def test_roundtrip(self):
+        values: Final = (0, 1, 35, 36, 100, 999999, 1700000000)
+        for val in values:
+            result = to_base36(val)
+            reconstructed = int(result, 36)
+            assert reconstructed == val
+
+
+class TestBuildOutputFilename:
+    def test_with_dash_in_name(self):
+        name: Final = "20260310-123456-author-article title here"
+        result: Final = _build_output_filename(name)
+        assert result.startswith("../dropcaster-docker/audio/")
+        assert result.endswith(".mp3")
+        assert "author-" in result
+        assert "20260310-123456-" in result
+
+    def test_without_dash_in_name(self):
+        name: Final = "20260310-123456-articleonly"
+        result: Final = _build_output_filename(name)
+        assert result.startswith("../dropcaster-docker/audio/")
+        assert result.endswith(".mp3")
+        assert "articleonly" in result
+
+
+class TestBuildTitleForTag:
+    def test_with_from_and_title(self):
+        metadata: Final[PMap[str, str]] = pmap({"from": "Author", "title": "Article Title"})
+        result: Final = _build_title_for_tag(metadata, "fallback")
+        assert result.startswith("Author- ")
+        assert result.endswith("- Article Title")
+
+    def test_without_from_uses_meta_title(self):
+        metadata: Final[PMap[str, str]] = pmap({"title": "Article Title"})
+        result: Final = _build_title_for_tag(metadata, "fallback")
+        assert result == "Article Title"
+
+    def test_without_from_or_title_uses_file_title(self):
+        metadata: Final[PMap[str, str]] = pmap({})
+        result: Final = _build_title_for_tag(metadata, "fallback")
+        assert result == "fallback"
+
+    def test_base36_in_middle(self):
+        metadata: Final[PMap[str, str]] = pmap({"from": "Author", "title": "Title"})
+        result: Final = _build_title_for_tag(metadata, "fallback")
+        parts = result.split("- ")
+        assert len(parts) == 3
+        base36_part: Final = parts[1].strip()
+        int(base36_part, 36)
+
+
+class TestDescriptionParams:
+    def test_frozen(self):
+        params: Final = DescriptionParams(summary="s", title="t", source_url="u", source_kind="k")
+        with pytest.raises(AttributeError):
+            params.summary = "new"  # pyright: ignore[reportAttributeAccessIssue]
+
+    def test_defaults(self):
+        params: Final = DescriptionParams(summary="s", title="t", source_url="u", source_kind="k")
+        assert not params.source_name
+        assert not params.intake_type
+
+    def test_slots(self):
+        params: Final = DescriptionParams(summary="s", title="t", source_url="u", source_kind="k")
+        assert hasattr(params, "__slots__")

--- a/text-to-speech/text_to_speech.py
+++ b/text-to-speech/text_to_speech.py
@@ -1,3 +1,4 @@
+import datetime
 import functools
 import logging
 import math
@@ -6,31 +7,53 @@ import os
 import pathlib
 import re
 import uuid
-from datetime import datetime
-from glob import glob
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final
 
 from google import genai
 from google.cloud import texttospeech
-from mutagen.id3 import ID3, TIT2, TT3, WXXX, ID3NoHeaderError
-from pydub import AudioSegment
+from mutagen.id3 import ID3, TIT2, TT3, WXXX, ID3NoHeaderError  # pyright: ignore[reportPrivateImportUsage]
+from pydub import AudioSegment  # type: ignore[import-untyped]  # pyright: ignore[reportMissingTypeStubs]
+from pyrsistent import PMap, PVector, pmap, pvector
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-input_dir = "../prepare-text/text-input-cleaned"
-temp_output_dir = "temp-output"
-final_output_dir = "../dropcaster-docker/audio"
-summary_model = "gemini-3.1-flash-lite-preview"
-_gemini_client = None
+INPUT_DIR: Final = "../prepare-text/text-input-cleaned"
+TEMP_OUTPUT_DIR: Final = "temp-output"
+FINAL_OUTPUT_DIR: Final = "../dropcaster-docker/audio"
+SUMMARY_MODEL: Final = "gemini-3.1-flash-lite-preview"
+_BASE36_YEAR_THRESHOLD: Final = 2037
+_BASE36_ALPHABET: Final = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+INTAKE_TYPE_LABELS: Final[PMap[str, str]] = pmap(
+    {
+        "email": "Email",
+        "rss": "RSS",
+        "link": "Link",
+        "youtube": "YouTube",
+    }
+)
+
+_gemini_client: genai.Client | None = None
 
 
-def split_metadata(raw_text):
+def _get_gemini_client() -> genai.Client:
+    global _gemini_client  # noqa: PLW0603
+    if _gemini_client is None:
+        _gemini_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    return _gemini_client
+
+
+def split_metadata(raw_text: str) -> tuple[PMap[str, str], str]:
     if not raw_text.startswith("META_"):
-        return {}, raw_text
+        return pmap({}), raw_text
     logging.info("Parsing metadata header")
-    lines = raw_text.splitlines()
-    metadata = {}
-    current_key = None
-    content_start = len(lines)
+    lines: Final = raw_text.splitlines()
+    # Mutable: accumulate metadata then freeze to PMap at return boundary
+    metadata_acc: dict[str, str] = {}
+    current_key: str | None = None
+    content_start: int = len(lines)
     for idx, line in enumerate(lines):
         if line.startswith("META_"):
             if ":" not in line:
@@ -38,238 +61,245 @@ def split_metadata(raw_text):
                 break
             key, value = line.split(":", 1)
             current_key = key.replace("META_", "").lower()
-            metadata[current_key] = value.strip()
+            metadata_acc[current_key] = value.strip()
             continue
         if line.startswith((" ", "\t")) and current_key:
-            metadata[current_key] = (
-                f"{metadata.get(current_key, '')} {line.strip()}".strip()
-            )
+            metadata_acc[current_key] = f"{metadata_acc.get(current_key, '')} {line.strip()}".strip()
             continue
         if not line.strip():
             content_start = idx + 1
             break
         content_start = idx
         break
-    content = "\n".join(lines[content_start:]) if content_start < len(lines) else ""
-    return metadata, content
+    content: Final = "\n".join(lines[content_start:]) if content_start < len(lines) else ""
+    return pmap(metadata_acc), content
 
 
-def get_gemini_client():
-    global _gemini_client
-    if _gemini_client is None:
-        _gemini_client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-    return _gemini_client
-
-
-def generate_summary(text, title):
+def generate_summary(text: str, title: str) -> str:
     if not text.strip():
         logging.info("Summary skipped: empty content")
         return ""
     logging.info("Generating summary via Gemini")
-    prompt = (
+    prompt: Final = (
         "Summarize the article in 2-3 sentences. Focus on key points and keep it concise.\n\n"
         f"Title: {title}\n\nArticle:\n{text}"
     )
     try:
-        client = get_gemini_client()
-        response = client.models.generate_content(
-            model=summary_model,
+        client: Final = _get_gemini_client()
+        response: Final = client.models.generate_content(  # pyright: ignore[reportUnknownMemberType]
+            model=SUMMARY_MODEL,
             contents=prompt,
         )
         logging.info("Summary generated")
-        return response.text.strip()
-    except Exception as exc:
-        logging.exception("Summary generation failed: %s", exc)
+        response_text: Final = response.text
+        if response_text is None:
+            return ""
+        return response_text.strip()
+    except Exception:
+        logging.exception("Summary generation failed")
         return ""
 
 
-INTAKE_TYPE_LABELS = {
-    "email": "Email",
-    "rss": "RSS",
-    "link": "Link",
-    "youtube": "YouTube",
-}
+@dataclass(frozen=True, slots=True)
+class DescriptionParams:
+    summary: str
+    title: str
+    source_url: str
+    source_kind: str
+    source_name: str = ""
+    intake_type: str = ""
 
 
-def build_description(summary, title, source_url, source_kind, source_name="", intake_type=""):
-    description_body = summary or "Summary unavailable."
-    title_line = title or "Untitled"
-    parts = [description_body, f"Title: {title_line}"]
-    if intake_type:
-        intake_label = INTAKE_TYPE_LABELS.get(intake_type, intake_type)
-        parts.append(f"Via: {intake_label}")
-    if source_url:
-        display_text = source_url
-        if source_kind == "beehiiv" and source_name:
-            display_text = source_name
-        parts.append(f'Source: <a href="{source_url}">{display_text}</a>')
+def build_description(params: DescriptionParams) -> str:
+    description_body: Final = params.summary or "Summary unavailable."
+    title_line: Final = params.title or "Untitled"
+    # Mutable: accumulate parts then freeze to PVector at return boundary
+    parts_acc: list[str] = [description_body, f"Title: {title_line}"]
+    if params.intake_type:
+        intake_label: Final = INTAKE_TYPE_LABELS.get(params.intake_type, params.intake_type)
+        parts_acc.append(f"Via: {intake_label}")
+    if params.source_url:
+        display_text: str = params.source_url
+        if params.source_kind == "beehiiv" and params.source_name:
+            display_text = params.source_name
+        parts_acc.append(f'Source: <a href="{params.source_url}">{display_text}</a>')
+    parts: Final[PVector[str]] = pvector(parts_acc)
     return "<br/><br/>".join(parts)
 
 
-def apply_id3_tags(mp3_path, description, source_url, title) -> None:
+def apply_id3_tags(mp3_path: str, description: str, source_url: str, title: str) -> None:
+    # Mutable: mutagen ID3 requires mutable dict-like objects
     logging.info("Writing ID3 tags to MP3")
     try:
         tags = ID3(mp3_path)
     except ID3NoHeaderError:
         tags = ID3()
     if title:
-        tags.add(TIT2(encoding=3, text=title))
+        tags.add(TIT2(encoding=3, text=title))  # pyright: ignore[reportUnknownMemberType]
     if description:
-        tags.add(TT3(encoding=3, text=description))
+        tags.add(TT3(encoding=3, text=description))  # pyright: ignore[reportUnknownMemberType]
     if source_url:
-        tags.add(WXXX(encoding=3, desc="Source", url=source_url))
-    tags.save(mp3_path, v1=2)
+        tags.add(WXXX(encoding=3, desc="Source", url=source_url))  # pyright: ignore[reportUnknownMemberType]
+    _ = tags.save(mp3_path, v1=2)  # pyright: ignore[reportUnknownMemberType]
 
 
-def to_base36(value):
-    alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+def to_base36(value: int) -> str:
     if value == 0:
         return "0"
-    digits = []
+    # Mutable: accumulate digits then freeze to PVector
+    digits_acc: list[str] = []
     while value:
         value, remainder = divmod(value, 36)
-        digits.append(alphabet[remainder])
+        digits_acc.append(_BASE36_ALPHABET[remainder])
+    digits: Final[PVector[str]] = pvector(digits_acc)
     return "".join(reversed(digits))
 
 
+def _build_output_filename(name: str) -> str:
+    current_datetime: Final = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%d")
+    date_and_dash_from_text_file: Final = name[:16]
+    name_without_date: Final = name[16:]
+    dash_index: Final = name_without_date.find("-")
+
+    if dash_index != -1:
+        return (
+            f"{FINAL_OUTPUT_DIR}/{name_without_date[: dash_index + 1]}"
+            f" {date_and_dash_from_text_file}"
+            f" {name_without_date[dash_index + 1 :]}-{current_datetime}.mp3"
+        )
+    return f"{FINAL_OUTPUT_DIR}/{name_without_date}-{date_and_dash_from_text_file}{current_datetime}.mp3"
+
+
+def _build_title_for_tag(metadata: Mapping[str, str], file_title: str) -> str:
+    meta_from: Final = metadata.get("from", "").strip()
+    meta_title: Final = metadata.get("title", "").strip()
+    if meta_from and meta_title:
+        now: Final = datetime.datetime.now(tz=datetime.UTC)
+        base36_width: Final = 6 if now.year <= _BASE36_YEAR_THRESHOLD else 7
+        unix_seconds_base36: Final = to_base36(int(now.timestamp())).zfill(base36_width)
+        return f"{meta_from}- {unix_seconds_base36}- {meta_title}"
+    return meta_title or file_title
+
+
 def process_files() -> None:
-    txt_files = sorted(glob(f"{input_dir}/*.txt"))
+    txt_files: Final = sorted(pathlib.Path(INPUT_DIR).glob("*.txt"))
     for f in txt_files:
-        text_to_speech(f)
+        text_to_speech(str(f))
 
 
-def text_to_speech(incoming_filename) -> None:
-    with pathlib.Path(incoming_filename).open("rb") as filename:
-        logging.info(f"Synthesizing speech for email {filename.name}")
-        name = pathlib.Path(filename.name).name.replace(".txt", "")
-        data = filename.read()
-        input_text_raw = data.decode("utf8")
-        metadata, content_text = split_metadata(input_text_raw)
-        # initialize the API client
-        client = texttospeech.TextToSpeechClient()
-        mp3files = []
-        # we can send up to 5000 characters per request, so split up the text
-        min_step_size = 3000
-        max_step_size = 5000
-        compiled_regex_for_first_whitespace = re.compile(r"(\r\n|\r|\n|\.)+\s+")
-        next_text_starter_position = 0
-        counter = 0
-        max_steps = math.floor(1 + len(content_text) / min_step_size)
-        if len(content_text) > 0:
-            meta_from = metadata.get("from", "").strip()
-            meta_title = metadata.get("title", "").strip()
-            meta_source_url = metadata.get("source_url", "").strip()
-            meta_source_kind = metadata.get("source_kind", "").strip()
-            meta_source_name = metadata.get("source_name", "").strip()
-            meta_intake_type = metadata.get("intake_type", "").strip()
-            if meta_title or meta_source_url:
-                logging.info("Using metadata for summary and description")
-            summary = generate_summary(content_text, meta_title)
-            description = build_description(
-                summary,
-                meta_title,
-                meta_source_url,
-                meta_source_kind,
-                meta_source_name,
-                meta_intake_type,
+def text_to_speech(incoming_filename: str) -> None:
+    incoming_path: Final = pathlib.Path(incoming_filename)
+    raw_bytes: Final = incoming_path.read_bytes()
+    logging.info("Synthesizing speech for email %s", incoming_path.name)
+    name: Final = incoming_path.stem
+    input_text_raw: Final = raw_bytes.decode("utf8")
+    metadata: PMap[str, str]
+    content_text: str
+    metadata, content_text = split_metadata(input_text_raw)
+    # Mutable: google TTS client requires mutable request dicts
+    client: Final = texttospeech.TextToSpeechClient()
+    # Mutable: accumulate mp3 filenames then freeze to PVector
+    mp3files_acc: list[str] = []
+    min_step_size: Final = 3000
+    max_step_size: Final = 5000
+    compiled_regex_for_first_whitespace: Final = re.compile(r"(\r\n|\r|\n|\.)+\s+")
+    next_text_starter_position: int = 0
+    counter: int = 0
+    max_steps: Final = math.floor(1 + len(content_text) / min_step_size)
+    if len(content_text) > 0:
+        meta_source_url: Final = metadata.get("source_url", "").strip()
+        meta_source_kind: Final = metadata.get("source_kind", "").strip()
+        meta_source_name: Final = metadata.get("source_name", "").strip()
+        meta_intake_type: Final = metadata.get("intake_type", "").strip()
+        meta_title: Final = metadata.get("title", "").strip()
+        if meta_title or meta_source_url:
+            logging.info("Using metadata for summary and description")
+        summary: Final = generate_summary(content_text, meta_title)
+        description: Final = build_description(
+            DescriptionParams(
+                summary=summary,
+                title=meta_title,
+                source_url=meta_source_url,
+                source_kind=meta_source_kind,
+                source_name=meta_source_name,
+                intake_type=meta_intake_type,
+            ),
+        )
+        while next_text_starter_position < len(content_text):
+            counter += 1
+            first_whitespace_after_min_step_size_search = compiled_regex_for_first_whitespace.search(
+                content_text,
+                next_text_starter_position + min_step_size,
+                next_text_starter_position + max_step_size,
             )
-            while next_text_starter_position < len(content_text):
-                counter += 1
-                first_whitespace_after_min_step_size_search = (
-                    compiled_regex_for_first_whitespace.search(
-                        content_text,
-                        next_text_starter_position + min_step_size,
-                        next_text_starter_position + max_step_size,
-                    )
-                )
-                if first_whitespace_after_min_step_size_search is not None:
-                    first_whitespace_after_min_step_size = (
-                        first_whitespace_after_min_step_size_search.end()
-                    )
-                else:
-                    first_whitespace_after_min_step_size = (
-                        next_text_starter_position + max_step_size
-                    )
-                    if first_whitespace_after_min_step_size < len(content_text):
-                        logging.info(
-                            f"max_step_size met before end of email {filename.name}",
-                        )
-                text_to_process = content_text[
-                    next_text_starter_position:first_whitespace_after_min_step_size
-                ]
-                next_text_starter_position = first_whitespace_after_min_step_size
-
-                synthesis_input = texttospeech.SynthesisInput(text=text_to_process)
-                voice = texttospeech.VoiceSelectionParams(
-                    language_code="en-US",
-                    name="en-US-Wavenet-F",
-                )
-                audio_config = texttospeech.AudioConfig(
-                    audio_encoding=texttospeech.AudioEncoding.MP3,
-                )
-                logging.info(
-                    "Synthesizing speech for file %s of at most %s",
-                    counter,
-                    max_steps,
-                )
-                response = client.synthesize_speech(
-                    request={
-                        "input": synthesis_input,
-                        "voice": voice,
-                        "audio_config": audio_config,
-                    },
-                )
-                mp3_filename = f"{temp_output_dir}/{uuid.uuid4()}.mp3"
-                with pathlib.Path(mp3_filename).open("wb") as out:
-                    # Write the response to the output file.
-                    out.write(response.audio_content)
-                    logging.info('Audio content written to file "%s"', mp3_filename)
-                mp3files.append(mp3_filename)
-
-            mp3_segments = mp3files
-            segments = [AudioSegment.from_mp3(f) for f in mp3_segments]
-
-            logging.info(f"Stitching together {len(segments)} mp3 files for {name}")
-            audio = functools.reduce(operator.add, segments)
-
-            current_datetime = datetime.now().strftime("%Y%m%d")
-            date_and_dash_from_text_file = name[:16]
-            name_without_date = name[16:]
-            # Check if "-" exists in name_without_date
-            dash_index = name_without_date.find("-")
-
-            if dash_index != -1:
-                # If "-" exists, insert the date after the first "-" with an additional "-" after it
-                output_filename = f"{final_output_dir}/{name_without_date[: dash_index + 1]} {date_and_dash_from_text_file} {name_without_date[dash_index + 1 :]}-{current_datetime}.mp3"
+            if first_whitespace_after_min_step_size_search is not None:
+                first_whitespace_after_min_step_size: int = first_whitespace_after_min_step_size_search.end()
             else:
-                # If "-" does not exist, add "-" before and after the date at the end
-                output_filename = f"{final_output_dir}/{name_without_date}-{date_and_dash_from_text_file}{current_datetime}.mp3"
+                first_whitespace_after_min_step_size = next_text_starter_position + max_step_size
+                if first_whitespace_after_min_step_size < len(content_text):
+                    logging.info(
+                        "max_step_size met before end of email %s",
+                        incoming_path.name,
+                    )
+            text_to_process = content_text[next_text_starter_position:first_whitespace_after_min_step_size]
+            next_text_starter_position = first_whitespace_after_min_step_size
 
-            logging.info("Exporting %s", output_filename)
-            audio.export(output_filename, format="mp3")
-            file_title = os.path.splitext(pathlib.Path(output_filename).name)[0]
-            file_title = re.sub(r"-\d{8}$", "", file_title)
-            if meta_from and meta_title:
-                now = datetime.now()
-                base36_width = 6 if now.year <= 2037 else 7
-                unix_seconds_base36 = to_base36(int(now.timestamp())).zfill(
-                    base36_width,
-                )
-                title_for_tag = f"{meta_from}- {unix_seconds_base36}- {meta_title}"
-            else:
-                title_for_tag = meta_title or file_title
-            apply_id3_tags(output_filename, description, meta_source_url, title_for_tag)
-
-            logging.info("Removing intermediate files")
-            for f in mp3_segments:
-                pathlib.Path(f).unlink()
-
-            logging.info("Removing original text file")
-            pathlib.Path(incoming_filename).unlink()
-        else:
-            logging.warning(
-                f"Skipping {filename.name}: file has no content.",
+            # Mutable: google TTS API requires mutable request dict
+            synthesis_input = texttospeech.SynthesisInput(text=text_to_process)
+            voice = texttospeech.VoiceSelectionParams(
+                language_code="en-US",
+                name="en-US-Wavenet-F",
             )
+            audio_config = texttospeech.AudioConfig(
+                audio_encoding=texttospeech.AudioEncoding.MP3,
+            )
+            logging.info(
+                "Synthesizing speech for file %s of at most %s",
+                counter,
+                max_steps,
+            )
+            response = client.synthesize_speech(  # pyright: ignore[reportUnknownMemberType]
+                request={
+                    "input": synthesis_input,
+                    "voice": voice,
+                    "audio_config": audio_config,
+                },
+            )
+            mp3_filename = f"{TEMP_OUTPUT_DIR}/{uuid.uuid4()}.mp3"
+            _ = pathlib.Path(mp3_filename).write_bytes(response.audio_content)
+            logging.info('Audio content written to file "%s"', mp3_filename)
+            mp3files_acc.append(mp3_filename)
+
+        mp3files: Final[PVector[str]] = pvector(mp3files_acc)
+        # Mutable: pydub requires list of AudioSegment objects
+        segments: Final[list[AudioSegment]] = [
+            AudioSegment.from_mp3(seg)  # pyright: ignore[reportUnknownMemberType]
+            for seg in mp3files
+        ]  # type: ignore[no-untyped-call]
+
+        logging.info("Stitching together %s mp3 files for %s", len(segments), name)
+        audio: Final[AudioSegment] = functools.reduce(operator.add, segments)  # type: ignore[arg-type]  # pyright: ignore[reportAny]
+
+        output_filename: Final = _build_output_filename(name)
+
+        logging.info("Exporting %s", output_filename)
+        _ = audio.export(output_filename, format="mp3")  # type: ignore[no-untyped-call]  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        file_title: str = pathlib.Path(output_filename).stem
+        file_title = re.sub(r"-\d{8}$", "", file_title)
+        title_for_tag: Final = _build_title_for_tag(metadata, file_title)
+        apply_id3_tags(output_filename, description, meta_source_url, title_for_tag)
+
+        logging.info("Removing intermediate files")
+        for seg_file in mp3files:
+            pathlib.Path(seg_file).unlink()
+
+        logging.info("Removing original text file")
+        incoming_path.unlink()
+    else:
+        logging.warning(
+            "Skipping %s: file has no content.",
+            incoming_path.name,
+        )
 
 
 if __name__ == "__main__":

--- a/text-to-speech/uv.lock
+++ b/text-to-speech/uv.lock
@@ -153,6 +153,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -390,6 +399,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
 name = "mutagen"
 version = "1.47.0"
 source = { registry = "https://pypi.org/simple" }
@@ -412,6 +430,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/97/88b4254a2ff93ed2eaed725f77b7d3d2d8d7973bf134359ce786db894faf/nodejs_wheel_binaries-24.13.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ad6383613f3485a75b054647a09f1cd56d12380d7459184eebcf4a5d403f35c", size = 62244373 },
     { url = "https://files.pythonhosted.org/packages/4e/c3/0e13a3da78f08cb58650971a6957ac7bfef84164b405176e53ab1e3584e2/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_amd64.whl", hash = "sha256:605be4763e3ef427a3385a55da5a1bcf0a659aa2716eebbf23f332926d7e5f23", size = 41345528 },
     { url = "https://files.pythonhosted.org/packages/a3/f1/0578d65b4e3dc572967fd702221ea1f42e1e60accfb6b0dd8d8f15410139/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_arm64.whl", hash = "sha256:2e3431d869d6b2dbeef1d469ad0090babbdcc8baaa72c01dd3cc2c6121c96af5", size = 39054688 },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
 ]
 
 [[package]]
@@ -570,6 +606,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "pyrsistent"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/3a/5031723c09068e9c8c2f0bc25c3a9245f2b1d1aea8396c787a408f2b95ca/pyrsistent-0.20.0.tar.gz", hash = "sha256:4c48f78f62ab596c679086084d0dd13254ae4f3d6c72a83ffdf5ebdef8f265a4", size = 103642 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/ee/ff2ed52032ac1ce2e7ba19e79bd5b05d152ebfb77956cf08fcd6e8d760ea/pyrsistent-0.20.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:09848306523a3aba463c4b49493a760e7a6ca52e4826aa100ee99d8d39b7ad1e", size = 83537 },
+    { url = "https://files.pythonhosted.org/packages/80/f1/338d0050b24c3132bcfc79b68c3a5f54bce3d213ecef74d37e988b971d8a/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a14798c3005ec892bbada26485c2eea3b54109cb2533713e355c806891f63c5e", size = 122615 },
+    { url = "https://files.pythonhosted.org/packages/07/3a/e56d6431b713518094fae6ff833a04a6f49ad0fbe25fb7c0dc7408e19d20/pyrsistent-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b14decb628fac50db5e02ee5a35a9c0772d20277824cfe845c8a8b717c15daa3", size = 122335 },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/5f40a4d5e985a43b43f607250e766cdec28904682c3505eb0bd343a4b7db/pyrsistent-0.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e2c116cc804d9b09ce9814d17df5edf1df0c624aba3b43bc1ad90411487036d", size = 118510 },
+    { url = "https://files.pythonhosted.org/packages/1c/13/e6a22f40f5800af116c02c28e29f15c06aa41cb2036f6a64ab124647f28b/pyrsistent-0.20.0-cp312-cp312-win32.whl", hash = "sha256:e78d0c7c1e99a4a45c99143900ea0546025e41bb59ebc10182e947cf1ece9174", size = 60865 },
+    { url = "https://files.pythonhosted.org/packages/75/ef/2fa3b55023ec07c22682c957808f9a41836da4cd006b5f55ec76bf0fbfa6/pyrsistent-0.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:4021a7f963d88ccd15b523787d18ed5e5269ce57aa4037146a2377ff607ae87d", size = 63239 },
+    { url = "https://files.pythonhosted.org/packages/23/88/0acd180010aaed4987c85700b7cc17f9505f3edb4e5873e4dc67f613e338/pyrsistent-0.20.0-py3-none-any.whl", hash = "sha256:c55acc4733aad6560a7f5f818466631f07efc001fd023f34a6c203f8b6df0f0b", size = 58106 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -659,12 +735,14 @@ dependencies = [
     { name = "google-genai" },
     { name = "mutagen" },
     { name = "pydub" },
+    { name = "pyrsistent" },
     { name = "requests" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "types-beautifulsoup4" },
     { name = "types-requests" },
@@ -677,12 +755,14 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "mutagen", specifier = ">=1.47.0" },
     { name = "pydub", specifier = ">=0.25.1" },
+    { name = "pyrsistent", specifier = ">=0.20.0" },
     { name = "requests", specifier = ">=2.32.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.20.0" },
+    { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.7.0" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0" },
     { name = "types-requests", specifier = ">=2.32.0" },


### PR DESCRIPTION
## Summary
- **Lint cleanup**: Resolved all ruff check, ruff format, and basedpyright errors across all 4 subprojects (prepare-text, imap, rss, text-to-speech). Updated root pyproject.toml with appropriate rule ignores and complexity limits.
- **Pyrsistent immutability**: Applied immutable data patterns using `PMap`, `PVector`, `freeze()`, `thaw()` across all scripts. Functions accept `Mapping`/`Sequence` params and return concrete immutable types. Mutable escape hatches documented where third-party APIs require mutation.
- **Unit tests**: Added 179 tests total — 71 (prepare-text), 42 (imap), 31 (rss), 35 (text-to-speech). Found and fixed a real bug in prepare-text override matching (`evaluate_match` was receiving the full override dict instead of just the match block).
- **CI**: GitHub Actions workflow runs pytest, ruff check, ruff format --check, and basedpyright on all 4 subprojects for every PR and push to main.
- **Documentation**: Updated CLAUDE.md and README.md with prepare-text pipeline step, test commands, CI info, immutability conventions, and corrected lint config details.

## Test plan
- [x] All 179 tests pass locally across all 4 subprojects
- [x] `ruff check` clean in all subprojects
- [x] `ruff format --check` clean in all subprojects
- [x] `basedpyright` reports 0 errors in all subprojects
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)